### PR TITLE
Introducing FlytePropeller TURBO Mode #minor

### DIFF
--- a/cmd/kubectl-flyte/cmd/get.go
+++ b/cmd/kubectl-flyte/cmd/get.go
@@ -92,7 +92,8 @@ func (g *GetOpts) iterateOverWorkflows(f func(*v1alpha1.FlyteWorkflow) error, ba
 			return err
 		}
 		for _, w := range wList.Items {
-			if err := f(&w); err != nil {
+			_w := w
+			if err := f(&_w); err != nil {
 				return err
 			}
 			counter++
@@ -127,7 +128,8 @@ func (g *GetOpts) iterateOverQuotas(f func(quota *v12.ResourceQuota) error, batc
 			return err
 		}
 		for _, r := range rq.Items {
-			if err := f(&r); err != nil {
+			_r := r
+			if err := f(&_r); err != nil {
 				return err
 			}
 			counter++

--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,6 @@ tasks:
       - container
       - sidecar
       - K8S-ARRAY
-      - qubole-hive-executor
     # Uncomment to enable sagemaker plugin
     #      - sagemaker_training
     #      - sagemaker_hyperparameter_tuning
@@ -95,7 +94,7 @@ event:
   rate: 500
   capacity: 1000
 admin:
-  endpoint: localhost:30081
+  endpoint: localhost:80
   insecure: true
 catalog-cache:
   type: noop

--- a/pkg/compiler/errors/compiler_errors.go
+++ b/pkg/compiler/errors/compiler_errors.go
@@ -83,7 +83,7 @@ const (
 func NewBranchNodeNotSpecified(branchNodeID string) *CompileError {
 	return newError(
 		BranchNodeIDNotFound,
-		fmt.Sprintf("BranchNode not assigned"),
+		"BranchNode not assigned",
 		branchNodeID,
 	)
 }

--- a/pkg/compiler/validators/interface.go
+++ b/pkg/compiler/validators/interface.go
@@ -70,13 +70,15 @@ func ValidateUnderlyingInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs e
 
 				// Compute exposed inputs as the union of all required inputs and any input overwritten by the node.
 				exposedInputs := map[string]*core.Variable{}
-				for name, p := range inputs.Parameters {
-					if p.GetRequired() {
-						exposedInputs[name] = p.Var
-					} else if containsBindingByVariableName(node.GetInputs(), name) {
-						exposedInputs[name] = p.Var
+				if inputs != nil && inputs.Parameters != nil {
+					for name, p := range inputs.Parameters {
+						if p.GetRequired() {
+							exposedInputs[name] = p.Var
+						} else if containsBindingByVariableName(node.GetInputs(), name) {
+							exposedInputs[name] = p.Var
+						}
+						// else, the param has a default value and is not being overwritten by the node
 					}
-					// else, the param has a default value and is not being overwritten by the node
 				}
 
 				iface = &core.TypedInterface{

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -47,8 +47,8 @@ var (
 			MaxNodeRetriesOnSystemFailures: 3,
 			InterruptibleFailureThreshold:  1,
 		},
-		EnableFastFollow: true,
-		MaxStreakLength:  5,
+		EnableTurboMode: true,
+		MaxStreakLength: 5,
 	}
 )
 
@@ -76,8 +76,8 @@ type Config struct {
 	MaxDatasetSizeBytes    int64                `json:"max-output-size-bytes" pflag:",Maximum size of outputs per task"`
 	KubeConfig             KubeClientConfig     `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
 	NodeConfig             NodeConfig           `json:"node-config,omitempty" pflag:",config for a workflow node"`
-	EnableFastFollow       bool                 `json:"enable-fast-follow" pflag:",Boolean flag that enables Fast Follow mode, this makes Propeller proceed to another round on successful write to etcD."`
-	MaxStreakLength        int                  `json:"max-streak-length" pflag:",Maximum number of consecutive rounds that one propeller worker can use for one workflow if fast follow mode is enabled."`
+	EnableTurboMode        bool                 `json:"enable-turbo-mode" pflag:",Boolean flag that enables Turbo-mode, this makes Propeller proceed to another round on successful write to etcD."`
+	MaxStreakLength        int                  `json:"max-streak-length" pflag:",Maximum number of consecutive rounds that one propeller worker can use for one workflow if turbo-mode is enabled."`
 }
 
 type KubeClientConfig struct {

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	MaxDatasetSizeBytes    int64                `json:"max-output-size-bytes" pflag:",Maximum size of outputs per task"`
 	KubeConfig             KubeClientConfig     `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
 	NodeConfig             NodeConfig           `json:"node-config,omitempty" pflag:",config for a workflow node"`
+	EnableFastFollow       bool					`json:"enable-fast-follow" pflag:",Boolean flag that enables Fast Follow mode, this makes Propeller proceed to another round on successful write to etcD."`
 }
 
 type KubeClientConfig struct {

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -47,8 +47,7 @@ var (
 			MaxNodeRetriesOnSystemFailures: 3,
 			InterruptibleFailureThreshold:  1,
 		},
-		EnableTurboMode: true,
-		MaxStreakLength: 5,
+		MaxStreakLength: 5, // Turbo mode is enabled by default
 	}
 )
 
@@ -76,8 +75,7 @@ type Config struct {
 	MaxDatasetSizeBytes    int64                `json:"max-output-size-bytes" pflag:",Maximum size of outputs per task"`
 	KubeConfig             KubeClientConfig     `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
 	NodeConfig             NodeConfig           `json:"node-config,omitempty" pflag:",config for a workflow node"`
-	EnableTurboMode        bool                 `json:"enable-turbo-mode" pflag:",Boolean flag that enables Turbo-mode, this makes Propeller proceed to another round on successful write to etcD."`
-	MaxStreakLength        int                  `json:"max-streak-length" pflag:",Maximum number of consecutive rounds that one propeller worker can use for one workflow if turbo-mode is enabled."`
+	MaxStreakLength        int                  `json:"max-streak-length" pflag:",Maximum number of consecutive rounds that one propeller worker can use for one workflow - >1 => turbo-mode is enabled."`
 }
 
 type KubeClientConfig struct {

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -48,7 +48,7 @@ var (
 			InterruptibleFailureThreshold:  1,
 		},
 		EnableFastFollow: true,
-		MaxStreakLength: 5,
+		MaxStreakLength:  5,
 	}
 )
 
@@ -76,9 +76,8 @@ type Config struct {
 	MaxDatasetSizeBytes    int64                `json:"max-output-size-bytes" pflag:",Maximum size of outputs per task"`
 	KubeConfig             KubeClientConfig     `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
 	NodeConfig             NodeConfig           `json:"node-config,omitempty" pflag:",config for a workflow node"`
-	EnableFastFollow       bool					`json:"enable-fast-follow" pflag:",Boolean flag that enables Fast Follow mode, this makes Propeller proceed to another round on successful write to etcD."`
+	EnableFastFollow       bool                 `json:"enable-fast-follow" pflag:",Boolean flag that enables Fast Follow mode, this makes Propeller proceed to another round on successful write to etcD."`
 	MaxStreakLength        int                  `json:"max-streak-length" pflag:",Maximum number of consecutive rounds that one propeller worker can use for one workflow if fast follow mode is enabled."`
-
 }
 
 type KubeClientConfig struct {

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -47,6 +47,8 @@ var (
 			MaxNodeRetriesOnSystemFailures: 3,
 			InterruptibleFailureThreshold:  1,
 		},
+		EnableFastFollow: true,
+		MaxStreakLength: 5,
 	}
 )
 
@@ -75,6 +77,8 @@ type Config struct {
 	KubeConfig             KubeClientConfig     `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
 	NodeConfig             NodeConfig           `json:"node-config,omitempty" pflag:",config for a workflow node"`
 	EnableFastFollow       bool					`json:"enable-fast-follow" pflag:",Boolean flag that enables Fast Follow mode, this makes Propeller proceed to another round on successful write to etcD."`
+	MaxStreakLength        int                  `json:"max-streak-length" pflag:",Maximum number of consecutive rounds that one propeller worker can use for one workflow if fast follow mode is enabled."`
+
 }
 
 type KubeClientConfig struct {

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -201,6 +201,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 			mutatedWf = RecordSystemError(w, err)
 			p.metrics.SystemError.Inc(ctx)
 		} else if mutatedWf == nil {
+			logger.Errorf(ctx, "Should not happen! Mutation resulted in a nil workflow!")
 			return nil
 		} else {
 			if !w.GetExecutionStatus().IsTerminated() {
@@ -225,9 +226,11 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 		// nothing other than resource status has been updated.
 		newWf, updateErr := p.wfStore.Update(ctx, mutatedWf, workflowstore.PriorityClassCritical)
 		if updateErr != nil {
+			t.Stop()
 			return updateErr
 		}
 		if err != nil {
+			t.Stop()
 			// An error was encountered during the round. Let us return, so that we can back-off gracefully
 			return err
 		}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -185,7 +185,12 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 	streak := 0
 	defer p.metrics.StreakLength.Add(ctx, float64(streak))
 
-	for streak = 0; streak < p.cfg.MaxStreakLength; streak++ {
+	maxLength := p.cfg.MaxStreakLength
+	if maxLength <= 0 {
+		maxLength = 1
+	}
+
+	for streak = 0; streak < ; streak++ {
 		mutatedWf, err := p.TryMutateWorkflow(ctx, w)
 		if err != nil {
 			// NOTE We are overriding the deepcopy here, as we are essentially ingnoring all mutations

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -185,7 +185,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 	streak := 0
 	defer p.metrics.StreakLength.Add(ctx, float64(streak))
 
-	for streak = 0; streak < p.cfg.MaxTTLInHours; streak++ {
+	for streak = 0; streak < p.cfg.MaxStreakLength; streak++ {
 		mutatedWf, err := p.TryMutateWorkflow(ctx, w)
 		if err != nil {
 			// NOTE We are overriding the deepcopy here, as we are essentially ingnoring all mutations

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -190,7 +190,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 		maxLength = 1
 	}
 
-	for streak = 0; streak < ; streak++ {
+	for streak = 0; streak < maxLength; streak++ {
 		mutatedWf, err := p.TryMutateWorkflow(ctx, w)
 		if err != nil {
 			// NOTE We are overriding the deepcopy here, as we are essentially ingnoring all mutations

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -449,6 +449,214 @@ func TestPropeller_Handle(t *testing.T) {
 	})
 }
 
+func TestPropeller_Handle_TurboMode(t *testing.T) {
+	// TODO unit tests need to fixed
+	scope := promutils.NewTestScope()
+	ctx := context.TODO()
+	s := workflowstore.NewInMemoryWorkflowStore()
+	exec := &mockExecutor{}
+	cfg := &config.Config{
+		MaxWorkflowRetries: 0,
+		EnableTurboMode:    true,
+		MaxStreakLength:    5,
+	}
+
+	const namespace = "test"
+	const name = "123"
+
+	p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+
+	t.Run("error", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+		}))
+		called := false
+		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
+			if called {
+				return fmt.Errorf("already called once")
+			}
+			called = true
+			return fmt.Errorf("failed")
+		}
+		assert.Error(t, p.Handle(ctx, namespace, name))
+
+		r, err := s.Get(ctx, namespace, name)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseReady, r.GetExecutionStatus().GetPhase())
+		assert.Equal(t, 0, len(r.Finalizers))
+		assert.Equal(t, uint32(1), r.Status.FailedAttempts)
+		assert.False(t, HasCompletedLabel(r))
+	})
+
+	t.Run("abort", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+			Status: v1alpha1.WorkflowStatus{
+				FailedAttempts: 1,
+			},
+		}))
+
+		called := false
+		exec.HandleAbortedCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow, maxRetries uint32) error {
+			if called {
+				return fmt.Errorf("already called once")
+			}
+			called = true
+			w.GetExecutionStatus().UpdatePhase(v1alpha1.WorkflowPhaseFailed, "done", nil)
+			return nil
+		}
+		assert.NoError(t, p.Handle(ctx, namespace, name))
+
+		r, err := s.Get(ctx, namespace, name)
+
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseFailed, r.GetExecutionStatus().GetPhase())
+		assert.Equal(t, 0, len(r.Finalizers))
+		assert.True(t, HasCompletedLabel(r))
+		assert.Equal(t, uint32(1), r.Status.FailedAttempts)
+	})
+
+	t.Run("abort-error", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+			Status: v1alpha1.WorkflowStatus{
+				FailedAttempts: 1,
+				Phase:          v1alpha1.WorkflowPhaseRunning,
+			},
+		}))
+
+		called := false
+		exec.HandleAbortedCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow, maxRetries uint32) error {
+			if called {
+				return fmt.Errorf("already called once")
+			}
+			called = true
+			return fmt.Errorf("abort error")
+		}
+		assert.Error(t, p.Handle(ctx, namespace, name))
+		r, err := s.Get(ctx, namespace, name)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseRunning, r.GetExecutionStatus().GetPhase())
+		assert.Equal(t, 0, len(r.Finalizers))
+		assert.False(t, HasCompletedLabel(r))
+		assert.Equal(t, uint32(2), r.Status.FailedAttempts)
+	})
+
+	t.Run("noUpdate", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       name,
+				Namespace:  namespace,
+				Finalizers: []string{"f1"},
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+			Status: v1alpha1.WorkflowStatus{
+				Phase: v1alpha1.WorkflowPhaseSucceeding,
+			},
+		}))
+		called := false
+		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
+			if called {
+				return fmt.Errorf("already called once")
+			}
+			called = true
+			w.GetExecutionStatus().UpdatePhase(v1alpha1.WorkflowPhaseSucceeding, "", nil)
+			return nil
+		}
+		assert.NoError(t, p.Handle(ctx, namespace, name))
+
+		r, err := s.Get(ctx, namespace, name)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseSucceeding, r.GetExecutionStatus().GetPhase())
+		assert.False(t, HasCompletedLabel(r))
+		assert.Equal(t, 1, len(r.Finalizers))
+	})
+
+	t.Run("happy-nochange", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+		}))
+		called := 0
+		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
+			if called >= 2 {
+				return fmt.Errorf("already called once")
+			}
+			called++
+			w.GetExecutionStatus().UpdatePhase(v1alpha1.WorkflowPhaseSucceeding, "done", nil)
+			return nil
+		}
+		assert.NoError(t, p.Handle(ctx, namespace, name))
+
+		r, err := s.Get(ctx, namespace, name)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseSucceeding, r.GetExecutionStatus().GetPhase())
+		assert.Equal(t, 1, len(r.Finalizers))
+		assert.False(t, HasCompletedLabel(r))
+		assert.Equal(t, uint32(0), r.Status.FailedAttempts)
+	})
+
+	t.Run("happy-success", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+		}))
+		called := 0
+		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
+			if called >= 2 {
+				return fmt.Errorf("already called once")
+			}
+			if called == 0 {
+				w.GetExecutionStatus().UpdatePhase(v1alpha1.WorkflowPhaseSucceeding, "done", nil)
+			} else {
+				w.GetExecutionStatus().UpdatePhase(v1alpha1.WorkflowPhaseSuccess, "done", nil)
+			}
+			called++
+			return nil
+		}
+		assert.NoError(t, p.Handle(ctx, namespace, name))
+
+		r, err := s.Get(ctx, namespace, name)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseSuccess.String(), r.GetExecutionStatus().GetPhase().String())
+		assert.Equal(t, 0, len(r.Finalizers))
+		assert.True(t, HasCompletedLabel(r))
+		assert.Equal(t, uint32(0), r.Status.FailedAttempts)
+		assert.Equal(t, 2, called)
+	})
+
+}
+
 func TestPropellerHandler_Initialize(t *testing.T) {
 	scope := promutils.NewTestScope()
 	ctx := context.TODO()
@@ -461,4 +669,12 @@ func TestPropellerHandler_Initialize(t *testing.T) {
 	p := NewPropellerHandler(ctx, cfg, s, exec, scope)
 
 	assert.NoError(t, p.Initialize(ctx))
+}
+
+func TestShouldExitCurrentEvaluationLoop(t *testing.T) {
+	assert.True(t, ShouldExitCurrentEvaluationLoop(false, false, "x", "y"))
+	assert.True(t, ShouldExitCurrentEvaluationLoop(true, true, "x", "y"))
+	assert.True(t, ShouldExitCurrentEvaluationLoop(true, false, "x", "x"))
+	assert.True(t, ShouldExitCurrentEvaluationLoop(false, true, "x", "x"))
+	assert.False(t, ShouldExitCurrentEvaluationLoop(true, false, "x", "y"))
 }

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -457,7 +457,6 @@ func TestPropeller_Handle_TurboMode(t *testing.T) {
 	exec := &mockExecutor{}
 	cfg := &config.Config{
 		MaxWorkflowRetries: 0,
-		EnableTurboMode:    true,
 		MaxStreakLength:    5,
 	}
 
@@ -669,12 +668,4 @@ func TestPropellerHandler_Initialize(t *testing.T) {
 	p := NewPropellerHandler(ctx, cfg, s, exec, scope)
 
 	assert.NoError(t, p.Initialize(ctx))
-}
-
-func TestShouldExitCurrentEvaluationLoop(t *testing.T) {
-	assert.True(t, ShouldExitCurrentEvaluationLoop(false, false, "x", "y"))
-	assert.True(t, ShouldExitCurrentEvaluationLoop(true, true, "x", "y"))
-	assert.True(t, ShouldExitCurrentEvaluationLoop(true, false, "x", "x"))
-	assert.True(t, ShouldExitCurrentEvaluationLoop(false, true, "x", "x"))
-	assert.False(t, ShouldExitCurrentEvaluationLoop(true, false, "x", "y"))
 }

--- a/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -286,7 +286,8 @@ func (d dynamicNodeTaskNodeHandler) getLaunchPlanInterfaces(ctx context.Context,
 
 	var launchPlanInterfaces = make([]common.InterfaceProvider, len(launchPlanIDs))
 	for idx, id := range launchPlanIDs {
-		lp, err := d.lpReader.GetLaunchPlan(ctx, &id)
+		idVal := id
+		lp, err := d.lpReader.GetLaunchPlan(ctx, &idVal)
 		if err != nil {
 			logger.Debugf(ctx, "Error fetching launch plan definition from admin")
 			if launchplan.IsNotFound(err) || launchplan.IsUserError(err) {

--- a/pkg/controller/nodes/task/fakeplugins/next_phase_state_plugin.go
+++ b/pkg/controller/nodes/task/fakeplugins/next_phase_state_plugin.go
@@ -84,7 +84,7 @@ func (n NextPhaseStatePlugin) Finalize(ctx context.Context, tCtx pluginCore.Task
 
 func NewPhaseBasedPlugin() NextPhaseStatePlugin {
 	return NextPhaseStatePlugin{
-		id:    fmt.Sprintf("next_phase_plugin"),
+		id:    "next_phase_plugin",
 		props: pluginCore.PluginProperties{},
 	}
 }

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -275,7 +275,7 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 			return nil
 		case v1alpha1.WorkflowPhaseRunning:
 			wfEvent.Phase = core.WorkflowExecution_RUNNING
-			wStatus.UpdatePhase(v1alpha1.WorkflowPhaseRunning, fmt.Sprintf("Workflow Started"), nil)
+			wStatus.UpdatePhase(v1alpha1.WorkflowPhaseRunning, "Workflow Started", nil)
 			wfEvent.OccurredAt = utils.GetProtoTime(wStatus.GetStartedAt())
 		case v1alpha1.WorkflowPhaseHandlingFailureNode:
 			fallthrough

--- a/pkg/controller/workflowstore/inmemory.go
+++ b/pkg/controller/workflowstore/inmemory.go
@@ -50,8 +50,10 @@ func (i *InmemoryWorkflowStore) UpdateStatus(ctx context.Context, w *v1alpha1.Fl
 		if w.Name != "" && w.Namespace != "" {
 			if m, ok := i.store[w.Namespace]; ok {
 				if _, ok := m[w.Name]; ok {
-					m[w.Name] = w
-					return w, nil
+					newW := w.DeepCopy()
+					newW.ResourceVersion = w.ResourceVersion + "x"
+					m[w.Name] = newW
+					return newW, nil
 				}
 			}
 

--- a/pkg/controller/workflowstore/inmemory.go
+++ b/pkg/controller/workflowstore/inmemory.go
@@ -51,6 +51,7 @@ func (i *InmemoryWorkflowStore) UpdateStatus(ctx context.Context, w *v1alpha1.Fl
 			if m, ok := i.store[w.Namespace]; ok {
 				if _, ok := m[w.Name]; ok {
 					newW := w.DeepCopy()
+					// Appends to the resource version to ensure that resource version has been updated
 					newW.ResourceVersion = w.ResourceVersion + "x"
 					m[w.Name] = newW
 					return newW, nil
@@ -69,6 +70,9 @@ func (i *InmemoryWorkflowStore) Update(ctx context.Context, w *v1alpha1.FlyteWor
 	return i.UpdateStatus(ctx, w, priorityClass)
 }
 
+// Returns an inmemory store, that will update the resource version for every update automatically. This is a good
+// idea to test that resource version checks work, but does not represent that the object was actually updated or not
+// The resource version is ALWAYS updated.
 func NewInMemoryWorkflowStore() *InmemoryWorkflowStore {
 	return &InmemoryWorkflowStore{
 		store: map[string]map[string]*v1alpha1.FlyteWorkflow{},


### PR DESCRIPTION
# TL;DR
This PR adds a new configuration to FlytePropeller which is enabled by default. This improves the transition latency of FlytePropeller by an order of magnitude or more. Absolute comparison to come soon.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently FlytePropeller event loop is designed to make the smallest forward progress in each round. There are cases in which the round progress is purely book-keeping. For example moving a workflow from accepted to Running state. Moving a node from new to queued to running state. This is done so that state is resilient from crashes.

the turbo mode, essentially waits for the one of these rounds to complete and optimistically progresses to the next round using the updated state. To add safety to the optimistic progress we can configure bounds.

The psuedo algorithm
```
w -> Original workflow state
w1 -> updated workflow state

while w1 != w and round < configured:
     w1 = try_mutate(w)
     if w1 != w:
         record(w1)
         w = w1
         round++
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/676