### PR TITLE
Add support for custom KubeClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.18.20
-	github.com/flyteorg/flyteplugins v0.5.37
+	github.com/flyteorg/flyteplugins v0.5.38
 	github.com/flyteorg/flytestdlib v0.3.13
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.18.20
-	github.com/flyteorg/flyteplugins v0.5.35
+	github.com/flyteorg/flyteplugins v0.5.37
 	github.com/flyteorg/flytestdlib v0.3.13
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flyteorg/flyteidl v0.18.17/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
 github.com/flyteorg/flyteidl v0.18.20 h1:OGOb2FOHWL363Qp8uzbJeFbQBKYPT30+afv+8BnBlGs=
 github.com/flyteorg/flyteidl v0.18.20/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
-github.com/flyteorg/flyteplugins v0.5.35 h1:KEMOiA4B+lIxQ+l7FRHzVcPA234Td9+ursuJDm6I8dg=
-github.com/flyteorg/flyteplugins v0.5.35/go.mod h1:CxerBGWWEmNYmPxSMHnwQEr9cc1Fbo/g5fcABazU6Jo=
+github.com/flyteorg/flyteplugins v0.5.37 h1:9kl91k2xG5QJbhdSwoTa7XFnLIynBsidcwBlbsysr5s=
+github.com/flyteorg/flyteplugins v0.5.37/go.mod h1:CxerBGWWEmNYmPxSMHnwQEr9cc1Fbo/g5fcABazU6Jo=
 github.com/flyteorg/flytestdlib v0.3.13 h1:5ioA/q3ixlyqkFh5kDaHgmPyTP/AHtqq1K/TIbVLUzM=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flyteorg/flyteidl v0.18.17/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
 github.com/flyteorg/flyteidl v0.18.20 h1:OGOb2FOHWL363Qp8uzbJeFbQBKYPT30+afv+8BnBlGs=
 github.com/flyteorg/flyteidl v0.18.20/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
-github.com/flyteorg/flyteplugins v0.5.37 h1:9kl91k2xG5QJbhdSwoTa7XFnLIynBsidcwBlbsysr5s=
-github.com/flyteorg/flyteplugins v0.5.37/go.mod h1:CxerBGWWEmNYmPxSMHnwQEr9cc1Fbo/g5fcABazU6Jo=
+github.com/flyteorg/flyteplugins v0.5.38 h1:xAQ1J23cRxzwNDgzbmRuuvflq2PFetntRCjuM5RBfTw=
+github.com/flyteorg/flyteplugins v0.5.38/go.mod h1:CxerBGWWEmNYmPxSMHnwQEr9cc1Fbo/g5fcABazU6Jo=
 github.com/flyteorg/flytestdlib v0.3.13 h1:5ioA/q3ixlyqkFh5kDaHgmPyTP/AHtqq1K/TIbVLUzM=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -84,18 +84,6 @@ func newPluginMetrics(s promutils.Scope) PluginMetrics {
 	}
 }
 
-func AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetadata, o client.Object, cfg *config.K8sPluginConfig) {
-	o.SetNamespace(taskCtx.GetNamespace())
-	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
-	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
-	o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})
-	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
-	if cfg.InjectFinalizer {
-		f := append(o.GetFinalizers(), finalizer)
-		o.SetFinalizers(f)
-	}
-}
-
 func IsK8sObjectNotExists(err error) bool {
 	return k8serrors.IsNotFound(err) || k8serrors.IsGone(err) || k8serrors.IsResourceExpired(err)
 }
@@ -109,8 +97,25 @@ type PluginManager struct {
 	kubeClient      pluginsCore.KubeClient
 	metrics         PluginMetrics
 	// Per namespace-resource
-	backOffController    *backoff.Controller
-	resourceLevelMonitor *ResourceLevelMonitor
+	backOffController     *backoff.Controller
+	resourceLevelMonitor  *ResourceLevelMonitor
+	ignoreOwnerReferences bool
+}
+
+func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetadata, o k8s.Resource, cfg *config.K8sPluginConfig) {
+	o.SetNamespace(taskCtx.GetNamespace())
+	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
+	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
+	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
+
+	if !e.ignoreOwnerReferences {
+		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})
+	}
+
+	if cfg.InjectFinalizer {
+		f := append(o.GetFinalizers(), finalizer)
+		o.SetFinalizers(f)
+	}
 }
 
 func (e *PluginManager) GetProperties() pluginsCore.PluginProperties {
@@ -175,7 +180,7 @@ func (e *PluginManager) LaunchResource(ctx context.Context, tCtx pluginsCore.Tas
 		return pluginsCore.UnknownTransition, err
 	}
 
-	AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
+	e.AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
 	logger.Infof(ctx, "Creating Object: Type:[%v], Object:[%v/%v]", o.GetObjectKind().GroupVersionKind(), o.GetNamespace(), o.GetName())
 
 	key := backoff.ComposeResourceKey(o)
@@ -227,7 +232,7 @@ func (e *PluginManager) CheckResourcePhase(ctx context.Context, tCtx pluginsCore
 		return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskDefinition", fmt.Sprintf("Failed to build resource, caused by: %s", err.Error()), nil)), nil
 	}
 
-	AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
+	e.AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
 	nsName := k8stypes.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}
 	// Attempt to get resource from informer cache, if not found, retrieve it from API server.
 	if err := e.kubeClient.GetClient().Get(ctx, nsName, o); err != nil {
@@ -314,7 +319,7 @@ func (e PluginManager) Abort(ctx context.Context, tCtx pluginsCore.TaskExecution
 		return nil
 	}
 
-	AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
+	e.AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
 
 	err = e.kubeClient.GetClient().Delete(ctx, o)
 	if err != nil && !IsK8sObjectNotExists(err) {
@@ -352,7 +357,7 @@ func (e *PluginManager) Finalize(ctx context.Context, tCtx pluginsCore.TaskExecu
 			return nil
 		}
 
-		AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
+		e.AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
 		nsName := k8stypes.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}
 		// Attempt to get resource from informer cache, if not found, retrieve it from API server.
 		if err := e.kubeClient.GetClient().Get(ctx, nsName, o); err != nil {
@@ -392,7 +397,19 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 		return nil, errors.Errorf(errors.PluginInitializationFailed, "Failed to initialize plugin, enqueue Owner cannot be nil or empty.")
 	}
 
-	if iCtx.KubeClient() == nil {
+	kubeClient := iCtx.KubeClient()
+	if entry.NewKubeClient != nil {
+		kc, err := entry.NewKubeClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if kc != nil {
+			kubeClient = kc
+		}
+	}
+
+	if kubeClient == nil {
 		return nil, errors.Errorf(errors.PluginInitializationFailed, "Failed to initialize K8sResource Plugin, Kubeclient cannot be nil!")
 	}
 
@@ -401,14 +418,18 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 		Type: entry.ResourceToWatch,
 	}
 
-	ownerKind := iCtx.OwnerKind()
 	workflowParentPredicate := func(o metav1.Object) bool {
+		if entry.IgnoreOwnerReferences {
+			return true
+		}
+
 		ownerReference := metav1.GetControllerOf(o)
 		if ownerReference != nil {
-			if ownerReference.Kind == ownerKind {
+			if ownerReference.Kind == iCtx.OwnerKind() {
 				return true
 			}
 		}
+
 		return false
 	}
 
@@ -492,12 +513,13 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 	rm.RunCollectorOnce(ctx)
 
 	return &PluginManager{
-		id:                   entry.ID,
-		plugin:               entry.Plugin,
-		resourceToWatch:      entry.ResourceToWatch,
-		metrics:              newPluginMetrics(metricsScope),
-		kubeClient:           iCtx.KubeClient(),
-		resourceLevelMonitor: rm,
+		id:                    entry.ID,
+		plugin:                entry.Plugin,
+		resourceToWatch:       entry.ResourceToWatch,
+		metrics:               newPluginMetrics(metricsScope),
+		kubeClient:            kubeClient,
+		resourceLevelMonitor:  rm,
+		ignoreOwnerReferences: entry.IgnoreOwnerReferences,
 	}, nil
 }
 

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -585,8 +585,7 @@ func TestPluginManager_CustomKubeClient(t *testing.T) {
 	assert.Equal(t, newFakeClient, pluginManager.kubeClient)
 }
 
-func TestPluginManager_AddObjectMetadata_IgnoreOwnerReferences(t *testing.T) {
-	pluginManager := PluginManager{disableInjectOwnerReferences: true}
+func TestPluginManager_AddObjectMetadata(t *testing.T) {
 	genName := "genName"
 	ns := "ns"
 	or := v12.OwnerReference{}
@@ -594,43 +593,48 @@ func TestPluginManager_AddObjectMetadata_IgnoreOwnerReferences(t *testing.T) {
 	a := map[string]string{"aKey": "aVal"}
 	tm := getMockTaskExecutionMetadataCustom(genName, ns, a, l, or)
 
-	o := &v1.Pod{}
-	cfg := config.GetK8sPluginConfig()
-	pluginManager.AddObjectMetadata(tm, o, cfg)
-	assert.Equal(t, genName, o.GetName())
-	// empty OwnerReference since we are ignoring
-	assert.Equal(t, 0, len(o.GetOwnerReferences()))
-	assert.Equal(t, ns, o.GetNamespace())
-	assert.Equal(t, map[string]string{
-		"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
-		"aKey": "aVal",
-	}, o.GetAnnotations())
-	assert.Equal(t, l, o.GetLabels())
-	assert.Equal(t, 0, len(o.GetFinalizers()))
-}
-
-func TestPluginManager_AddObjectMetadata_InjectFinalizer(t *testing.T) {
-	pluginManager := PluginManager{
-		disableInjectOwnerReferences: true,
-		disableInjectFinalizer:       true,
-	}
-	genName := "genName"
-	ns := "ns"
-	or := v12.OwnerReference{}
-	l := map[string]string{"l1": "lv1"}
-	a := map[string]string{"aKey": "aVal"}
-	tm := getMockTaskExecutionMetadataCustom(genName, ns, a, l, or)
-
-	o := &v1.Pod{}
 	cfg := config.GetK8sPluginConfig()
 
-	t.Run("Disable enabled InjectFinalizer", func(t *testing.T) {
-		// enable finalizer injection
-		cfg.InjectFinalizer = true
+	t.Run("default", func(t *testing.T) {
+		o := &v1.Pod{}
+		pluginManager := PluginManager{}
+		pluginManager.AddObjectMetadata(tm, o, cfg)
+		assert.Equal(t, genName, o.GetName())
+		assert.Equal(t, []v12.OwnerReference{or}, o.GetOwnerReferences())
+		assert.Equal(t, ns, o.GetNamespace())
+		assert.Equal(t, map[string]string{
+			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+			"aKey": "aVal",
+		}, o.GetAnnotations())
+		assert.Equal(t, l, o.GetLabels())
+		assert.Equal(t, 0, len(o.GetFinalizers()))
+	})
+
+	t.Run("Disable OwnerReferences injection", func(t *testing.T) {
+		pluginManager := PluginManager{disableInjectOwnerReferences: true}
+		o := &v1.Pod{}
 		pluginManager.AddObjectMetadata(tm, o, cfg)
 		assert.Equal(t, genName, o.GetName())
 		// empty OwnerReference since we are ignoring
 		assert.Equal(t, 0, len(o.GetOwnerReferences()))
+		assert.Equal(t, ns, o.GetNamespace())
+		assert.Equal(t, map[string]string{
+			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+			"aKey": "aVal",
+		}, o.GetAnnotations())
+		assert.Equal(t, l, o.GetLabels())
+		assert.Equal(t, 0, len(o.GetFinalizers()))
+	})
+
+	t.Run("Disable enabled InjectFinalizer", func(t *testing.T) {
+		pluginManager := PluginManager{disableInjectFinalizer: true}
+		// enable finalizer injection
+		cfg.InjectFinalizer = true
+		o := &v1.Pod{}
+		pluginManager.AddObjectMetadata(tm, o, cfg)
+		assert.Equal(t, genName, o.GetName())
+		// empty OwnerReference since we are ignoring
+		assert.Equal(t, 1, len(o.GetOwnerReferences()))
 		assert.Equal(t, ns, o.GetNamespace())
 		assert.Equal(t, map[string]string{
 			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
@@ -641,12 +645,14 @@ func TestPluginManager_AddObjectMetadata_InjectFinalizer(t *testing.T) {
 	})
 
 	t.Run("Disable disabled InjectFinalizer", func(t *testing.T) {
+		pluginManager := PluginManager{disableInjectFinalizer: true}
 		// disable finalizer injection
 		cfg.InjectFinalizer = false
+		o := &v1.Pod{}
 		pluginManager.AddObjectMetadata(tm, o, cfg)
 		assert.Equal(t, genName, o.GetName())
 		// empty OwnerReference since we are ignoring
-		assert.Equal(t, 0, len(o.GetOwnerReferences()))
+		assert.Equal(t, 1, len(o.GetOwnerReferences()))
 		assert.Equal(t, ns, o.GetNamespace())
 		assert.Equal(t, map[string]string{
 			"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
@@ -655,29 +661,7 @@ func TestPluginManager_AddObjectMetadata_InjectFinalizer(t *testing.T) {
 		assert.Equal(t, l, o.GetLabels())
 		assert.Equal(t, 0, len(o.GetFinalizers()))
 	})
-}
 
-func TestPluginManager_AddObjectMetadata(t *testing.T) {
-	pluginManager := PluginManager{}
-	genName := "genName"
-	ns := "ns"
-	or := v12.OwnerReference{}
-	l := map[string]string{"l1": "lv1"}
-	a := map[string]string{"aKey": "aVal"}
-	tm := getMockTaskExecutionMetadataCustom(genName, ns, a, l, or)
-
-	o := &v1.Pod{}
-	cfg := config.GetK8sPluginConfig()
-	pluginManager.AddObjectMetadata(tm, o, cfg)
-	assert.Equal(t, genName, o.GetName())
-	assert.Equal(t, []v12.OwnerReference{or}, o.GetOwnerReferences())
-	assert.Equal(t, ns, o.GetNamespace())
-	assert.Equal(t, map[string]string{
-		"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
-		"aKey": "aVal",
-	}, o.GetAnnotations())
-	assert.Equal(t, l, o.GetLabels())
-	assert.Equal(t, 0, len(o.GetFinalizers()))
 }
 
 func TestResourceManagerConstruction(t *testing.T) {

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -624,7 +624,7 @@ func TestPluginManager_AddObjectMetadata_InjectFinalizer(t *testing.T) {
 	o := &v1.Pod{}
 	cfg := config.GetK8sPluginConfig()
 
-	t.Run("Disable enbaled InjectFinalizer", func(t *testing.T) {
+	t.Run("Disable enabled InjectFinalizer", func(t *testing.T) {
 		// enable finalizer injection
 		cfg.InjectFinalizer = true
 		pluginManager.AddObjectMetadata(tm, o, cfg)
@@ -641,7 +641,7 @@ func TestPluginManager_AddObjectMetadata_InjectFinalizer(t *testing.T) {
 	})
 
 	t.Run("Disable disabled InjectFinalizer", func(t *testing.T) {
-		// enable finalizer injection
+		// disable finalizer injection
 		cfg.InjectFinalizer = false
 		pluginManager.AddObjectMetadata(tm, o, cfg)
 		assert.Equal(t, genName, o.GetName())

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -570,13 +570,13 @@ func TestPluginManager_CustomKubeClient(t *testing.T) {
 	// common setup code
 	mockResourceHandler := &pluginsk8sMock.Plugin{}
 	mockResourceHandler.On("BuildResource", mock.Anything, tctx).Return(&v1.Pod{}, nil)
-	fakeClient := fake.NewFakeClient()
+	fakeClient := fake.NewClientBuilder().Build()
 	newFakeClient := &pluginsCoreMock.KubeClient{}
 	pluginManager, err := NewPluginManager(ctx, dummySetupContext(fakeClient), k8s.PluginEntry{
 		ID:              "x",
 		ResourceToWatch: &v1.Pod{},
 		Plugin:          mockResourceHandler,
-		NewKubeClient: func(ctx context.Context) (pluginsCore.KubeClient, error) {
+		CustomKubeClient: func(ctx context.Context) (pluginsCore.KubeClient, error) {
 			return newFakeClient, nil
 		},
 	}, NewResourceMonitorIndex())

--- a/pkg/controller/nodes/task/taskexec_context.go
+++ b/pkg/controller/nodes/task/taskexec_context.go
@@ -64,14 +64,6 @@ func (t taskExecutionMetadata) GetMaxAttempts() uint32 {
 	return t.maxAttempts
 }
 
-func (t taskExecutionMetadata) GetSecurityContext() core.SecurityContext {
-	return core.SecurityContext{
-		RunAs: &core.Identity{
-			K8SServiceAccount: t.GetK8sServiceAccount(),
-		},
-	}
-}
-
 type taskExecutionContext struct {
 	handler.NodeExecutionContext
 	tm  taskExecutionMetadata

--- a/pkg/controller/nodes/task/taskexec_context.go
+++ b/pkg/controller/nodes/task/taskexec_context.go
@@ -64,6 +64,14 @@ func (t taskExecutionMetadata) GetMaxAttempts() uint32 {
 	return t.maxAttempts
 }
 
+func (t taskExecutionMetadata) GetSecurityContext() core.SecurityContext {
+	return core.SecurityContext{
+		RunAs: &core.Identity{
+			K8SServiceAccount: t.GetK8sServiceAccount(),
+		},
+	}
+}
+
 type taskExecutionContext struct {
 	handler.NodeExecutionContext
 	tm  taskExecutionMetadata


### PR DESCRIPTION
This is an initial take on adding support for a custom KubeClient supplied by plugins. If `KubeClient` is added for a remote cluster we need to ignore `OwnerReferences`

@kumare3 @EngHabu let me know what you think. 

This will require https://github.com/flyteorg/flyteplugins/pull/154 and then a `flyteplugins` version bump

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue


## Tracking Issue
https://github.com/lyft/flyte/issues/<number>
