### PR TITLE
Use the LazyUploadingTaskReader #minor

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -107,7 +107,6 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	fmt.Printf("Started in-cluster mode\n")
 	return nil
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ propeller:
       type: bucket
       rate: 100
       capacity: 1000
+  # This config assumes using `make start` in flytesnacks repo to startup a DinD k3s container
   kube-config: "$HOME/kubeconfig/k3s/k3s.yaml"
   publish-k8s-events: true
   workflowStore:

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ propeller:
       type: bucket
       rate: 100
       capacity: 1000
-  kube-config: "$HOME/.kube/config"
+  kube-config: "$HOME/kubeconfig/k3s/k3s.yaml"
   publish-k8s-events: true
   workflowStore:
     policy: "ResourceVersionCache"
@@ -61,7 +61,7 @@ plugins:
       - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
     co-pilot:
       name: "flyte-copilot-"
-      image: "flyteplugins:24c62d97452ce83ad6b4fd24e0eea2b4c44ff0c6"
+      image: "ghcr.io/flyteorg/flytecopilot:v0.5.28"
       start-timeout: "5s"
   sagemaker:
     roleArn: "arn:aws:iam::123456789012:role/test-development"
@@ -94,7 +94,7 @@ event:
   rate: 500
   capacity: 1000
 admin:
-  endpoint: localhost:80
+  endpoint: localhost:30081
   insecure: true
 catalog-cache:
   type: noop

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.18.25
-	github.com/flyteorg/flyteplugins v0.5.40
+	github.com/flyteorg/flyteplugins v0.5.41-0.20210325000109-3b0a6f610ea0
 	github.com/flyteorg/flytestdlib v0.3.13
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.18.25
-	github.com/flyteorg/flyteplugins v0.5.41-0.20210325000109-3b0a6f610ea0
+	github.com/flyteorg/flyteplugins v0.5.41
 	github.com/flyteorg/flytestdlib v0.3.13
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flyteorg/flyteidl v0.18.25 h1:XbHwM4G1u5nGAcdKod+ENgbL84cHdNzQIWY+NajuHs8=
 github.com/flyteorg/flyteidl v0.18.25/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
-github.com/flyteorg/flyteplugins v0.5.41-0.20210325000109-3b0a6f610ea0 h1:Gy0N9rPjSw3z6b2LntWUBnQoQTGjlx/8Fk+lfF/SIL8=
-github.com/flyteorg/flyteplugins v0.5.41-0.20210325000109-3b0a6f610ea0/go.mod h1:ireF+bYk8xjw9BfcMbPN/hN5aZeBJpP0CoQYHkSRL+w=
+github.com/flyteorg/flyteplugins v0.5.41 h1:8n1Z55P59ICV4453Dk7fhaUbB944j3BMZ+ozywHczgU=
+github.com/flyteorg/flyteplugins v0.5.41/go.mod h1:ireF+bYk8xjw9BfcMbPN/hN5aZeBJpP0CoQYHkSRL+w=
 github.com/flyteorg/flytestdlib v0.3.13 h1:5ioA/q3ixlyqkFh5kDaHgmPyTP/AHtqq1K/TIbVLUzM=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flyteorg/flyteidl v0.18.25 h1:XbHwM4G1u5nGAcdKod+ENgbL84cHdNzQIWY+NajuHs8=
 github.com/flyteorg/flyteidl v0.18.25/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
-github.com/flyteorg/flyteplugins v0.5.40 h1:3Vaat/CzMv87hIuloVRKsPussO0271TUmtbCzBMTAN8=
-github.com/flyteorg/flyteplugins v0.5.40/go.mod h1:ireF+bYk8xjw9BfcMbPN/hN5aZeBJpP0CoQYHkSRL+w=
+github.com/flyteorg/flyteplugins v0.5.41-0.20210325000109-3b0a6f610ea0 h1:Gy0N9rPjSw3z6b2LntWUBnQoQTGjlx/8Fk+lfF/SIL8=
+github.com/flyteorg/flyteplugins v0.5.41-0.20210325000109-3b0a6f610ea0/go.mod h1:ireF+bYk8xjw9BfcMbPN/hN5aZeBJpP0CoQYHkSRL+w=
 github.com/flyteorg/flytestdlib v0.3.13 h1:5ioA/q3ixlyqkFh5kDaHgmPyTP/AHtqq1K/TIbVLUzM=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/pkg/controller/nodes/dynamic/handler.go
+++ b/pkg/controller/nodes/dynamic/handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/event"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog"
-	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -35,7 +34,7 @@ type TaskNodeHandler interface {
 	handler.Node
 	ValidateOutputAndCacheAdd(ctx context.Context, nodeID v1alpha1.NodeID, i io.InputReader,
 		r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig,
-		tr pluginCore.TaskReader, m catalog.Metadata) (catalog.Status, *io.ExecutionError, error)
+		tr ioutils.SimpleTaskReader, m catalog.Metadata) (catalog.Status, *io.ExecutionError, error)
 }
 
 type metrics struct {

--- a/pkg/controller/nodes/dynamic/mocks/task_node_handler.go
+++ b/pkg/controller/nodes/dynamic/mocks/task_node_handler.go
@@ -7,11 +7,11 @@ import (
 
 	catalog "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog"
 
-	core "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
-
 	handler "github.com/flyteorg/flytepropeller/pkg/controller/nodes/handler"
 
 	io "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
+
+	ioutils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -198,7 +198,7 @@ func (_m TaskNodeHandler_ValidateOutputAndCacheAdd) Return(_a0 catalog.Status, _
 	return &TaskNodeHandler_ValidateOutputAndCacheAdd{Call: _m.Call.Return(_a0, _a1, _a2)}
 }
 
-func (_m *TaskNodeHandler) OnValidateOutputAndCacheAdd(ctx context.Context, nodeID string, i io.InputReader, r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig, tr core.TaskReader, m catalog.Metadata) *TaskNodeHandler_ValidateOutputAndCacheAdd {
+func (_m *TaskNodeHandler) OnValidateOutputAndCacheAdd(ctx context.Context, nodeID string, i io.InputReader, r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig, tr ioutils.SimpleTaskReader, m catalog.Metadata) *TaskNodeHandler_ValidateOutputAndCacheAdd {
 	c := _m.On("ValidateOutputAndCacheAdd", ctx, nodeID, i, r, outputCommitter, executionConfig, tr, m)
 	return &TaskNodeHandler_ValidateOutputAndCacheAdd{Call: c}
 }
@@ -209,18 +209,18 @@ func (_m *TaskNodeHandler) OnValidateOutputAndCacheAddMatch(matchers ...interfac
 }
 
 // ValidateOutputAndCacheAdd provides a mock function with given fields: ctx, nodeID, i, r, outputCommitter, executionConfig, tr, m
-func (_m *TaskNodeHandler) ValidateOutputAndCacheAdd(ctx context.Context, nodeID string, i io.InputReader, r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig, tr core.TaskReader, m catalog.Metadata) (catalog.Status, *io.ExecutionError, error) {
+func (_m *TaskNodeHandler) ValidateOutputAndCacheAdd(ctx context.Context, nodeID string, i io.InputReader, r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig, tr ioutils.SimpleTaskReader, m catalog.Metadata) (catalog.Status, *io.ExecutionError, error) {
 	ret := _m.Called(ctx, nodeID, i, r, outputCommitter, executionConfig, tr, m)
 
 	var r0 catalog.Status
-	if rf, ok := ret.Get(0).(func(context.Context, string, io.InputReader, io.OutputReader, io.OutputWriter, v1alpha1.ExecutionConfig, core.TaskReader, catalog.Metadata) catalog.Status); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, io.InputReader, io.OutputReader, io.OutputWriter, v1alpha1.ExecutionConfig, ioutils.SimpleTaskReader, catalog.Metadata) catalog.Status); ok {
 		r0 = rf(ctx, nodeID, i, r, outputCommitter, executionConfig, tr, m)
 	} else {
 		r0 = ret.Get(0).(catalog.Status)
 	}
 
 	var r1 *io.ExecutionError
-	if rf, ok := ret.Get(1).(func(context.Context, string, io.InputReader, io.OutputReader, io.OutputWriter, v1alpha1.ExecutionConfig, core.TaskReader, catalog.Metadata) *io.ExecutionError); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, io.InputReader, io.OutputReader, io.OutputWriter, v1alpha1.ExecutionConfig, ioutils.SimpleTaskReader, catalog.Metadata) *io.ExecutionError); ok {
 		r1 = rf(ctx, nodeID, i, r, outputCommitter, executionConfig, tr, m)
 	} else {
 		if ret.Get(1) != nil {
@@ -229,7 +229,7 @@ func (_m *TaskNodeHandler) ValidateOutputAndCacheAdd(ctx context.Context, nodeID
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, string, io.InputReader, io.OutputReader, io.OutputWriter, v1alpha1.ExecutionConfig, core.TaskReader, catalog.Metadata) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, string, io.InputReader, io.OutputReader, io.OutputWriter, v1alpha1.ExecutionConfig, ioutils.SimpleTaskReader, catalog.Metadata) error); ok {
 		r2 = rf(ctx, nodeID, i, r, outputCommitter, executionConfig, tr, m)
 	} else {
 		r2 = ret.Error(2)

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -672,8 +672,8 @@ func (t Handler) Abort(ctx context.Context, nCtx handler.NodeExecutionContext, r
 			if r := recover(); r != nil {
 				t.metrics.pluginPanics.Inc(ctx)
 				stack := debug.Stack()
-				logger.Errorf(ctx, "Panic in plugin.Abort for TaskType [%s]", tCtx.tr.GetTaskType())
-				err = fmt.Errorf("panic when executing a plugin for TaskType [%s]. Stack: [%s]", tCtx.tr.GetTaskType(), string(stack))
+				logger.Errorf(ctx, "Panic in plugin.Abort for TaskType [%s]", ttype)
+				err = fmt.Errorf("panic when executing a plugin for TaskType [%s]. Stack: [%s]", ttype, string(stack))
 			}
 		}()
 
@@ -728,8 +728,8 @@ func (t Handler) Finalize(ctx context.Context, nCtx handler.NodeExecutionContext
 			if r := recover(); r != nil {
 				t.metrics.pluginPanics.Inc(ctx)
 				stack := debug.Stack()
-				logger.Errorf(ctx, "Panic in plugin.Finalize for TaskType [%s]", tCtx.tr.GetTaskType())
-				err = fmt.Errorf("panic when executing a plugin for TaskType [%s]. Stack: [%s]", tCtx.tr.GetTaskType(), string(stack))
+				logger.Errorf(ctx, "Panic in plugin.Finalize for TaskType [%s]", ttype)
+				err = fmt.Errorf("panic when executing a plugin for TaskType [%s]. Stack: [%s]", ttype, string(stack))
 			}
 		}()
 		childCtx := context.WithValue(ctx, pluginContextKey, p.GetID())

--- a/pkg/controller/nodes/task/pre_post_execution.go
+++ b/pkg/controller/nodes/task/pre_post_execution.go
@@ -3,6 +3,8 @@ package task
 import (
 	"context"
 
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
+
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog"
 	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
@@ -71,7 +73,7 @@ func (t *Handler) CheckCatalogCache(ctx context.Context, tr pluginCore.TaskReade
 
 func (t *Handler) ValidateOutputAndCacheAdd(ctx context.Context, nodeID v1alpha1.NodeID, i io.InputReader,
 	r io.OutputReader, outputCommitter io.OutputWriter, executionConfig v1alpha1.ExecutionConfig,
-	tr pluginCore.TaskReader, m catalog.Metadata) (catalog.Status, *io.ExecutionError, error) {
+	tr ioutils.SimpleTaskReader, m catalog.Metadata) (catalog.Status, *io.ExecutionError, error) {
 
 	tk, err := tr.Read(ctx)
 	if err != nil {

--- a/pkg/controller/nodes/task/taskexec_context_test.go
+++ b/pkg/controller/nodes/task/taskexec_context_test.go
@@ -144,7 +144,7 @@ func TestHandler_newTaskExecutionContext(t *testing.T) {
 	assert.Equal(t, got.psm.newStateVersion, uint8(10))
 	assert.NotNil(t, got.psm.newState)
 
-	assert.Equal(t, got.TaskReader(), tr)
+	assert.NotNil(t, got.TaskReader())
 	assert.Equal(t, got.MaxDatasetSizeBytes(), int64(1))
 	assert.NotNil(t, got.SecretManager())
 
@@ -159,7 +159,6 @@ func TestHandler_newTaskExecutionContext(t *testing.T) {
 
 	assert.EqualValues(t, got.ResourceManager().(resourcemanager.TaskResourceManager).GetResourcePoolInfo(), make([]*event.ResourcePoolInfo, 0))
 
-	// TODO @kumare fix this test
 	assert.NotNil(t, got.rm)
 
 	_, err = got.rm.AllocateResource(context.TODO(), "foo", "token", pluginCore.ResourceConstraintsSpec{})


### PR DESCRIPTION
# TL;DR
This PR uses latest flyteplugins - pluginmachinery interface, that replaces a simple TaskReader with a TaskReader that has a path interface. The path method returns a deterministic path that can be passed to the actual container task to execute.

Depends on: https://github.com/flyteorg/flyteplugins/pull/166

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/850

