### PR TITLE
Bug Fix and Perf Tweak #minor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.18.25
-	github.com/flyteorg/flyteplugins v0.5.41
+	github.com/flyteorg/flyteplugins v0.5.42
 	github.com/flyteorg/flytestdlib v0.3.13
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/flyteorg/flyteidl v0.18.25 h1:XbHwM4G1u5nGAcdKod+ENgbL84cHdNzQIWY+Naj
 github.com/flyteorg/flyteidl v0.18.25/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
 github.com/flyteorg/flyteplugins v0.5.41 h1:8n1Z55P59ICV4453Dk7fhaUbB944j3BMZ+ozywHczgU=
 github.com/flyteorg/flyteplugins v0.5.41/go.mod h1:ireF+bYk8xjw9BfcMbPN/hN5aZeBJpP0CoQYHkSRL+w=
+github.com/flyteorg/flyteplugins v0.5.42 h1:G4DRR2r8LlmkV+orXloDi1ly+M5WuvAaNlWFgGGyy3A=
+github.com/flyteorg/flyteplugins v0.5.42/go.mod h1:ireF+bYk8xjw9BfcMbPN/hN5aZeBJpP0CoQYHkSRL+w=
 github.com/flyteorg/flytestdlib v0.3.13 h1:5ioA/q3ixlyqkFh5kDaHgmPyTP/AHtqq1K/TIbVLUzM=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=

--- a/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -153,8 +153,8 @@ func (a *adminLaunchPlanExecutor) syncItem(ctx context.Context, batch cache.Batc
 			if IsWorkflowTerminated(exec.ExecutionClosure.Phase) {
 				logger.Debugf(ctx, "Workflow [%s] is already completed, will not fetch execution information", exec.ExecutionClosure.WorkflowId)
 				resp = append(resp, cache.ItemSyncResponse{
-					ID: obj.GetID(),
-					Item: exec,
+					ID:     obj.GetID(),
+					Item:   exec,
 					Action: cache.Unchanged,
 				})
 				continue

--- a/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -24,7 +24,8 @@ import (
 
 // IsWorkflowTerminated returns a true if the Workflow Phase is in a Terminal Phase, else returns a false
 func IsWorkflowTerminated(p core.WorkflowExecution_Phase) bool {
-	return p == core.WorkflowExecution_ABORTED || p == core.WorkflowExecution_FAILED || p == core.WorkflowExecution_SUCCEEDED
+	return p == core.WorkflowExecution_ABORTED || p == core.WorkflowExecution_FAILED ||
+		p == core.WorkflowExecution_SUCCEEDED || p == core.WorkflowExecution_TIMED_OUT
 }
 
 // Executor for Launchplans that executes on a remote FlyteAdmin service (if configured)
@@ -151,6 +152,11 @@ func (a *adminLaunchPlanExecutor) syncItem(ctx context.Context, batch cache.Batc
 		if exec.ExecutionClosure != nil {
 			if IsWorkflowTerminated(exec.ExecutionClosure.Phase) {
 				logger.Debugf(ctx, "Workflow [%s] is already completed, will not fetch execution information", exec.ExecutionClosure.WorkflowId)
+				resp = append(resp, cache.ItemSyncResponse{
+					ID: obj.GetID(),
+					Item: exec,
+					Action: cache.Unchanged,
+				})
 				continue
 			}
 		}

--- a/pkg/controller/nodes/subworkflow/launchplan/admin.go
+++ b/pkg/controller/nodes/subworkflow/launchplan/admin.go
@@ -22,6 +22,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// IsWorkflowTerminated returns a true if the Workflow Phase is in a Terminal Phase, else returns a false
+func IsWorkflowTerminated(p core.WorkflowExecution_Phase) bool {
+	return p == core.WorkflowExecution_ABORTED || p == core.WorkflowExecution_FAILED || p == core.WorkflowExecution_SUCCEEDED
+}
+
 // Executor for Launchplans that executes on a remote FlyteAdmin service (if configured)
 type adminLaunchPlanExecutor struct {
 	adminClient service.AdminServiceClient
@@ -141,6 +146,16 @@ func (a *adminLaunchPlanExecutor) syncItem(ctx context.Context, batch cache.Batc
 	resp = make([]cache.ItemSyncResponse, 0, len(batch))
 	for _, obj := range batch {
 		exec := obj.GetItem().(executionCacheItem)
+
+		// Is workflow already terminated, then no need to fetch information, also the item can be dropped from the cache
+		if exec.ExecutionClosure != nil {
+			if IsWorkflowTerminated(exec.ExecutionClosure.Phase) {
+				logger.Debugf(ctx, "Workflow [%s] is already completed, will not fetch execution information", exec.ExecutionClosure.WorkflowId)
+				continue
+			}
+		}
+
+		// Workflow is not already terminated, lets check the status
 		req := &admin.WorkflowExecutionGetRequest{
 			Id: &exec.WorkflowExecutionIdentifier,
 		}
@@ -167,6 +182,7 @@ func (a *adminLaunchPlanExecutor) syncItem(ctx context.Context, batch cache.Batc
 			continue
 		}
 
+		// Update the cache with the retrieved status
 		resp = append(resp, cache.ItemSyncResponse{
 			ID: obj.GetID(),
 			Item: executionCacheItem{

--- a/pkg/controller/nodes/subworkflow/launchplan/adminconfig.go
+++ b/pkg/controller/nodes/subworkflow/launchplan/adminconfig.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	defaultAdminConfig = &AdminConfig{
-		TPS:          5,
+		TPS:          100,
 		Burst:        10,
 		MaxCacheSize: 10000,
 		Workers:      10,
@@ -17,6 +17,8 @@ var (
 	adminConfigSection = ctrlConfig.MustRegisterSubSection("admin-launcher", defaultAdminConfig)
 )
 
+// AdminConfig provides a "admin-launcher" section in core Flytepropeller configuration and can be used to configure
+// the rate at which Flytepropeller can query for status of workflows in flyteadmin or create new executions
 type AdminConfig struct {
 	// TPS indicates the maximum transactions per second to flyte admin from this client.
 	// If it's zero, the created client will use DefaultTPS: 5

--- a/pkg/controller/workflowstore/config.go
+++ b/pkg/controller/workflowstore/config.go
@@ -9,19 +9,26 @@ import (
 type Policy = string
 
 const (
-	PolicyInMemory             = "InMemory"
-	PolicyPassThrough          = "PassThrough"
+	// PolicyInMemory provides an inmemory Workflow store which is useful for testing
+	PolicyInMemory = "InMemory"
+	// PolicyPassThrough just calls the underlying Clientset or the shared informer cache to get or write the workflow
+	PolicyPassThrough = "PassThrough"
+	// PolicyResourceVersionCache uses the resource version on the Workflow object, to determine if the inmemory copy
+	// of the workflow is stale
 	PolicyResourceVersionCache = "ResourceVersionCache"
 )
 
+// By default we will use the ResourceVersionCache example
 var (
 	defaultConfig = &Config{
-		Policy: PolicyPassThrough,
+		Policy: PolicyResourceVersionCache,
 	}
 
 	configSection = ctrlConfig.MustRegisterSubSection("workflowStore", defaultConfig)
 )
 
+// Config for Workflow access in the controller.
+// Various policies are available like - InMemory, PassThrough, ResourceVersionCache
 type Config struct {
 	Policy Policy `json:"policy" pflag:",Workflow Store Policy to initialize"`
 }

--- a/pkg/controller/workflowstore/iface.go
+++ b/pkg/controller/workflowstore/iface.go
@@ -15,6 +15,7 @@ const (
 	PriorityClassRegular
 )
 
+// FlyteWorkflow store interface provides an abstraction of accessing the actual FlyteWorkflow object.
 type FlyteWorkflow interface {
 	Get(ctx context.Context, namespace, name string) (*v1alpha1.FlyteWorkflow, error)
 	UpdateStatus(ctx context.Context, workflow *v1alpha1.FlyteWorkflow, priorityClass PriorityClass) (


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
 - Building a cache from Flyteadmin executions, should stop querying
flyteadmin, if the workflow is in terminal state
 - Default for Max streak length can be optimized to 8 (number of rounds
needed to complete one workflow start to end, with inmemory execution)
 - Other defaults set that have been hardened over time.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/882


