### PR TITLE
Compiler validates bound value for enum #patch

### DIFF
--- a/pkg/compiler/errors/compiler_errors.go
+++ b/pkg/compiler/errors/compiler_errors.go
@@ -78,6 +78,9 @@ const (
 
 	// A workflow is missing any nodes to execute
 	NoNodesFound ErrorCode = "NoNodesFound"
+
+	// Given value is not a legal Enum value (or not part of the defined set of enum values)
+	IllegalEnumValue ErrorCode = "IllegalEnumValue"
 )
 
 func NewBranchNodeNotSpecified(branchNodeID string) *CompileError {
@@ -189,6 +192,14 @@ func NewMismatchingBindingsErr(nodeID, sinkParam, expectedType, receivedType str
 	return newError(
 		MismatchingBindings,
 		fmt.Sprintf("Input [%v] on node [%v] expects bindings of type [%v].  Received [%v]", sinkParam, nodeID, expectedType, receivedType),
+		nodeID,
+	)
+}
+
+func NewIllegalEnumValueError(nodeID, sinkParam, receivedVal string, expectedVals []string) *CompileError {
+	return newError(
+		IllegalEnumValue,
+		fmt.Sprintf("Input [%v] on node [%v] is an Enum and expects value to be one of [%v].  Received [%v]", sinkParam, nodeID, expectedVals, receivedVal),
 		nodeID,
 	)
 }

--- a/pkg/compiler/validators/bindings.go
+++ b/pkg/compiler/validators/bindings.go
@@ -91,6 +91,21 @@ func validateBinding(w c.WorkflowBuilder, nodeID c.NodeID, nodeParam string, bin
 			errs.Collect(errors.NewMismatchingTypesErr(nodeID, nodeParam, literalType.String(), expectedType.String()))
 		}
 
+		if expectedType.GetEnumType() != nil {
+			v := binding.GetScalar().GetPrimitive().GetStringValue()
+			// Let us assert that the bound value is a correct enum Value
+			found := false
+			for _, ev := range expectedType.GetEnumType().Values {
+				if ev == v {
+					found = true
+					break
+				}
+			}
+			if !found {
+				errs.Collect(errors.NewIllegalEnumValueError(nodeID, nodeParam, v, expectedType.GetEnumType().Values))
+			}
+		}
+
 		return literalType, []c.NodeID{}, !errs.HasErrors()
 	default:
 		errs.Collect(errors.NewUnrecognizedValueErr(nodeID, reflect.TypeOf(binding.GetValue()).String()))

--- a/pkg/compiler/validators/bindings_test.go
+++ b/pkg/compiler/validators/bindings_test.go
@@ -105,6 +105,70 @@ func TestValidateBindings(t *testing.T) {
 		}
 	})
 
+	t.Run("Enum legal string", func(t *testing.T) {
+		wf := &mocks.WorkflowBuilder{}
+		n := &mocks.NodeBuilder{}
+		n.OnGetId().Return("node1")
+
+		bindings := []*core.Binding{
+			{
+				Var:     "x",
+				Binding: LiteralToBinding(coreutils.MustMakeLiteral("x")),
+			},
+		}
+
+		vars := &core.VariableMap{
+			Variables: map[string]*core.Variable{
+				"x": {
+					Type: &core.LiteralType{Type: &core.LiteralType_EnumType{
+						EnumType: &core.EnumType{
+							Values: []string{"x", "y", "z"},
+						},
+					}},
+				},
+			},
+		}
+
+		compileErrors := compilerErrors.NewCompileErrors()
+		_, ok := ValidateBindings(wf, n, bindings, vars, true, c.EdgeDirectionBidirectional, compileErrors)
+		assert.True(t, ok)
+		if compileErrors.HasErrors() {
+			assert.NoError(t, compileErrors)
+		}
+	})
+
+	t.Run("Enum illegal string", func(t *testing.T) {
+		wf := &mocks.WorkflowBuilder{}
+		n := &mocks.NodeBuilder{}
+		n.OnGetId().Return("node1")
+
+		bindings := []*core.Binding{
+			{
+				Var:     "m",
+				Binding: LiteralToBinding(coreutils.MustMakeLiteral("x")),
+			},
+		}
+
+		vars := &core.VariableMap{
+			Variables: map[string]*core.Variable{
+				"x": {
+					Type: &core.LiteralType{Type: &core.LiteralType_EnumType{
+						EnumType: &core.EnumType{
+							Values: []string{"x", "y", "z"},
+						},
+					}},
+				},
+			},
+		}
+
+		compileErrors := compilerErrors.NewCompileErrors()
+		_, ok := ValidateBindings(wf, n, bindings, vars, true, c.EdgeDirectionBidirectional, compileErrors)
+		assert.False(t, ok)
+		if !compileErrors.HasErrors() {
+			assert.Error(t, compileErrors)
+		}
+	})
+
 	t.Run("Maps", func(t *testing.T) {
 		wf := &mocks.WorkflowBuilder{}
 		n := &mocks.NodeBuilder{}


### PR DESCRIPTION

Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
The PR ensures that a bound value for Enums is valid at registration
/ compile time


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
https://docs.google.com/document/d/1rf0hMKbPebJ7jGYpsTDAbJ4ka58KIKD7EgWAEBIH06Q/edit#

## Tracking Issue
https://github.com/flyteorg/flyte/issues/590

## Follow-up issue
_NA_

