### PR TITLE
Fix case in which downstream nodes may incorrectly fail because of parentNodeID #minor

### DIFF
--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -273,6 +273,10 @@ func TestNodeExecutor_RecursiveNodeHandler_RecurseEndNode(t *testing.T) {
 	// Node not yet started
 	{
 		createSingleNodeWf := func(parentPhase v1alpha1.NodePhase, _ int) (v1alpha1.ExecutableWorkflow, v1alpha1.ExecutableNode, v1alpha1.ExecutableNodeStatus) {
+			sn := &v1alpha1.NodeSpec{
+				ID:   v1alpha1.StartNodeID,
+				Kind: v1alpha1.NodeKindStart,
+			}
 			n := &v1alpha1.NodeSpec{
 				ID:   v1alpha1.EndNodeID,
 				Kind: v1alpha1.NodeKindEnd,
@@ -292,7 +296,8 @@ func TestNodeExecutor_RecursiveNodeHandler_RecurseEndNode(t *testing.T) {
 				WorkflowSpec: &v1alpha1.WorkflowSpec{
 					ID: "wf",
 					Nodes: map[v1alpha1.NodeID]*v1alpha1.NodeSpec{
-						v1alpha1.EndNodeID: n,
+						v1alpha1.StartNodeID: sn,
+						v1alpha1.EndNodeID:   n,
 					},
 					Connections: v1alpha1.Connections{
 						Upstream: map[v1alpha1.NodeID][]v1alpha1.NodeID{
@@ -608,6 +613,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 			mockWf := &mocks.ExecutableWorkflow{}
 			mockWf.OnStartNode().Return(mockNodeN0)
 			mockWf.OnGetNode(nodeN2).Return(mockNode, true)
+			mockWf.OnGetNode(nodeN0).Return(mockNodeN0, true)
 			mockWf.OnGetNodeExecutionStatusMatch(mock.Anything, nodeN0).Return(mockN0Status)
 			mockWf.OnGetNodeExecutionStatusMatch(mock.Anything, nodeN2).Return(mockN2Status)
 			mockWf.OnGetConnections().Return(connections)
@@ -653,8 +659,8 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 					mock.MatchedBy(func(ctx context.Context) bool { return true }),
 					mock.MatchedBy(func(o handler.NodeExecutionContext) bool { return true }),
 				).Return(handler.UnknownTransition, fmt.Errorf("should not be called"))
-				h.On("FinalizeRequired").Return(false)
-				hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
+				h.OnFinalizeRequired().Return(false)
+				hf.OnGetHandler(v1alpha1.NodeKindTask).Return(h, nil)
 
 				mockWf, _ := setupNodePhase(test.parentNodePhase, test.currentNodePhase, test.expectedNodePhase)
 				startNode := mockWf.StartNode()
@@ -1095,6 +1101,11 @@ func TestNodeExecutor_RecursiveNodeHandler_UpstreamNotReady(t *testing.T) {
 	taskID := taskID
 
 	createSingleNodeWf := func(parentPhase v1alpha1.NodePhase, maxAttempts int) (v1alpha1.ExecutableWorkflow, v1alpha1.ExecutableNode, v1alpha1.ExecutableNodeStatus) {
+		startNode := &v1alpha1.NodeSpec{
+			Kind: v1alpha1.NodeKindStart,
+			ID:   v1alpha1.StartNodeID,
+		}
+
 		n := &v1alpha1.NodeSpec{
 			ID:      defaultNodeID,
 			TaskRef: &taskID,
@@ -1103,6 +1114,7 @@ func TestNodeExecutor_RecursiveNodeHandler_UpstreamNotReady(t *testing.T) {
 				MinAttempts: &maxAttempts,
 			},
 		}
+
 		ns := &v1alpha1.NodeStatus{}
 
 		return &v1alpha1.FlyteWorkflow{
@@ -1123,7 +1135,8 @@ func TestNodeExecutor_RecursiveNodeHandler_UpstreamNotReady(t *testing.T) {
 			WorkflowSpec: &v1alpha1.WorkflowSpec{
 				ID: "wf",
 				Nodes: map[v1alpha1.NodeID]*v1alpha1.NodeSpec{
-					defaultNodeID: n,
+					v1alpha1.StartNodeID: startNode,
+					defaultNodeID:        n,
 				},
 				Connections: v1alpha1.Connections{
 					Upstream: map[v1alpha1.NodeID][]v1alpha1.NodeID{
@@ -1228,6 +1241,7 @@ func TestNodeExecutor_RecursiveNodeHandler_BranchNode(t *testing.T) {
 
 				hf.OnGetHandlerMatch(v1alpha1.NodeKindTask).Return(h, nil)
 
+				now := v1.Time{Time: time.Now()}
 				parentBranchNodeID := "branchNode"
 				parentBranchNode := &mocks.ExecutableNode{}
 				parentBranchNode.OnGetID().Return(parentBranchNodeID)
@@ -1235,6 +1249,8 @@ func TestNodeExecutor_RecursiveNodeHandler_BranchNode(t *testing.T) {
 				parentBranchNodeStatus := &mocks.ExecutableNodeStatus{}
 				parentBranchNodeStatus.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
 				parentBranchNodeStatus.OnIsDirty().Return(false)
+				parentBranchNodeStatus.OnGetStartedAt().Return(&now)
+				parentBranchNodeStatus.OnGetLastUpdatedAt().Return(nil)
 				bns := &mocks.MutableBranchNodeStatus{}
 				parentBranchNodeStatus.OnGetBranchStatus().Return(bns)
 				bns.OnGetPhase().Return(test.parentNodePhase)
@@ -1271,6 +1287,7 @@ func TestNodeExecutor_RecursiveNodeHandler_BranchNode(t *testing.T) {
 				branchTakeNodeStatus.OnGetDataDir().Return("data")
 				branchTakeNodeStatus.OnGetParentNodeID().Return(&parentBranchNodeID)
 				branchTakeNodeStatus.OnGetParentTaskID().Return(nil)
+				branchTakeNodeStatus.OnGetStartedAt().Return(&now)
 
 				if test.phaseUpdateExpected {
 					var ee *core.ExecutionError

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1223,8 +1223,8 @@ func TestNodeExecutor_RecursiveNodeHandler_BranchNode(t *testing.T) {
 			expectedError       bool
 		}{
 			{"branchSuccess", v1alpha1.BranchNodeSuccess, v1alpha1.NodePhaseNotYetStarted, true, executors.NodePhaseQueued, false},
-			{"branchNotYetDone", v1alpha1.BranchNodeNotYetEvaluated, v1alpha1.NodePhaseNotYetStarted, false, executors.NodePhaseUndefined, true},
-			{"branchError", v1alpha1.BranchNodeError, v1alpha1.NodePhaseNotYetStarted, false, executors.NodePhaseUndefined, true},
+			{"branchNotYetDone", v1alpha1.BranchNodeNotYetEvaluated, v1alpha1.NodePhaseNotYetStarted, false, executors.NodePhasePending, false},
+			{"branchError", v1alpha1.BranchNodeError, v1alpha1.NodePhaseNotYetStarted, false, executors.NodePhasePending, false},
 		}
 
 		for _, test := range tests {

--- a/pkg/controller/nodes/predicate.go
+++ b/pkg/controller/nodes/predicate.go
@@ -56,15 +56,15 @@ func CanExecute(ctx context.Context, dag executors.DAGStructure, nl executors.No
 
 	skipped := false
 	for _, upstreamNodeID := range upstreamNodes {
+		upstreamNode, ok := nl.GetNode(upstreamNodeID)
+		if !ok {
+			return PredicatePhaseUndefined, errors.Errorf(errors.BadSpecificationError, nodeID, "Upstream node [%v] of node [%v] not defined", upstreamNodeID, nodeID)
+		}
+
 		upstreamNodeStatus := nl.GetNodeExecutionStatus(ctx, upstreamNodeID)
 
 		if upstreamNodeStatus.IsDirty() {
 			return PredicatePhaseNotReady, nil
-		}
-
-		upstreamNode, ok := nl.GetNode(upstreamNodeID)
-		if !ok {
-			return PredicatePhaseUndefined, errors.Errorf(errors.BadSpecificationError, nodeID, "Upstream node [%v] of node [%v] not defined", upstreamNodeID, nodeID)
 		}
 
 		if upstreamNode.GetBranchNode() != nil && upstreamNodeStatus.GetBranchStatus() != nil {

--- a/pkg/controller/nodes/predicate_test.go
+++ b/pkg/controller/nodes/predicate_test.go
@@ -21,7 +21,7 @@ func TestCanExecute(t *testing.T) {
 
 	t.Run("startNode", func(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(v1alpha1.StartNodeID)
+		mockNode.OnGetID().Return(v1alpha1.StartNodeID)
 		p, err := CanExecute(ctx, nil, nil, mockNode)
 		assert.NoError(t, err)
 		assert.Equal(t, PredicatePhaseReady, p)
@@ -31,7 +31,6 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockNodeStatus := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockNodeStatus.OnGetParentNodeID().Return(nil)
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 		mockWf := &mocks.ExecutableWorkflow{}
@@ -48,8 +47,42 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.OnGetParentNodeID().Return(nil)
 		mockN2Status.OnIsDirty().Return(false)
+		mockNode := &mocks.BaseNode{}
+		mockNode.OnGetID().Return(nodeN2)
+
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
+		mockN0Status := &mocks.ExecutableNodeStatus{}
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
+		mockN0Status.OnIsDirty().Return(false)
+
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
+		mockN1Status := &mocks.ExecutableNodeStatus{}
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
+		mockN1Status.OnIsDirty().Return(false)
+
+		mockWf := &mocks.ExecutableWorkflow{}
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
+		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetID().Return("w1")
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
+
+		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
+		assert.NoError(t, err)
+		assert.Equal(t, PredicatePhaseNotReady, p)
+	})
+
+	t.Run("upstreamConnectionsPartialReady", func(t *testing.T) {
+		// Setup
+		mockN2Status := &mocks.ExecutableNodeStatus{}
+		// No parent node
+		mockN2Status.OnIsDirty().Return(false)
+
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
@@ -58,7 +91,7 @@ func TestCanExecute(t *testing.T) {
 		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
@@ -73,53 +106,22 @@ func TestCanExecute(t *testing.T) {
 		assert.Equal(t, PredicatePhaseNotReady, p)
 	})
 
-	t.Run("upstreamConnectionsPartialReady", func(t *testing.T) {
-		// Setup
-		mockN2Status := &mocks.ExecutableNodeStatus{}
-		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
-
-		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
-
-		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseRunning)
-		mockN0Status.On("IsDirty").Return(false)
-
-		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN1Status.On("IsDirty").Return(false)
-
-		mockWf := &mocks.ExecutableWorkflow{}
-		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
-		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
-		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
-		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetID").Return("w1")
-
-		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
-		assert.NoError(t, err)
-		assert.Equal(t, PredicatePhaseNotReady, p)
-	})
-
 	t.Run("upstreamConnectionsCompletelyReady", func(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
@@ -127,7 +129,7 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
 
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -138,26 +140,25 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN1Status.On("IsDirty").Return(true)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN1Status.OnIsDirty().Return(true)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -168,26 +169,25 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseRunning)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSkipped)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -198,26 +198,25 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSkipped)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -228,26 +227,25 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSkipped)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSkipped)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -259,64 +257,29 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(nil)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseFailed)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseFailed)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseFailed)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseFailed)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
 		assert.Equal(t, PredicatePhaseSkip, p)
-	})
-
-	// Branch node tests
-
-	// ParentNode not found?
-	t.Run("upstreamConnectionsParentNodeNotFound", func(t *testing.T) {
-		// Setup
-		mockN2Status := &mocks.ExecutableNodeStatus{}
-		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(&nodeN0)
-		mockN2Status.On("IsDirty").Return(false)
-
-		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
-
-		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("IsDirty").Return(false)
-
-		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN1Status.On("IsDirty").Return(false)
-
-		mockWf := &mocks.ExecutableWorkflow{}
-		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
-		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
-		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
-		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetNode", nodeN0).Return(nil, false)
-		mockWf.On("GetID").Return("w1")
-
-		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
-		assert.Error(t, err)
-		assert.Equal(t, PredicatePhaseUndefined, p)
 	})
 
 	// ParentNode branch ready
@@ -324,34 +287,33 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(&nodeN0)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0BranchStatus := &mocks.MutableBranchNodeStatus{}
-		mockN0BranchStatus.On("GetPhase").Return(v1alpha1.BranchNodeSuccess)
+		mockN0BranchStatus.OnGetPhase().Return(v1alpha1.BranchNodeSuccess)
 		mockN0BranchNode := &mocks.ExecutableBranchNode{}
 
 		mockN0Node := &mocks.ExecutableNode{}
-		mockN0Node.On("GetBranchNode").Return(mockN0BranchNode)
+		mockN0Node.OnGetBranchNode().Return(mockN0BranchNode)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("GetBranchStatus").Return(mockN0BranchStatus)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetNode", nodeN0).Return(mockN0Node, true)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -363,34 +325,33 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(&nodeN0)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0BranchStatus := &mocks.MutableBranchNodeStatus{}
-		mockN0BranchStatus.On("GetPhase").Return(v1alpha1.BranchNodeSuccess)
+		mockN0BranchStatus.OnGetPhase().Return(v1alpha1.BranchNodeSuccess)
 
 		mockN0BranchNode := &mocks.ExecutableBranchNode{}
 		mockN0Node := &mocks.ExecutableNode{}
-		mockN0Node.On("GetBranchNode").Return(mockN0BranchNode)
+		mockN0Node.OnGetBranchNode().Return(mockN0BranchNode)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("GetBranchStatus").Return(mockN0BranchStatus)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseSkipped)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetNode", nodeN0).Return(mockN0Node, true)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)
@@ -402,34 +363,33 @@ func TestCanExecute(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
-		mockN2Status.On("GetParentNodeID").Return(&nodeN0)
-		mockN2Status.On("IsDirty").Return(false)
+		mockN2Status.OnIsDirty().Return(false)
 
 		mockNode := &mocks.BaseNode{}
-		mockNode.On("GetID").Return(nodeN2)
+		mockNode.OnGetID().Return(nodeN2)
 
 		mockN0BranchStatus := &mocks.MutableBranchNodeStatus{}
-		mockN0BranchStatus.On("GetPhase").Return(v1alpha1.BranchNodeSuccess)
+		mockN0BranchStatus.OnGetPhase().Return(v1alpha1.BranchNodeSuccess)
 
 		mockN0BranchNode := &mocks.ExecutableBranchNode{}
 		mockN0Node := &mocks.ExecutableNode{}
-		mockN0Node.On("GetBranchNode").Return(mockN0BranchNode)
+		mockN0Node.OnGetBranchNode().Return(mockN0BranchNode)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
-		mockN0Status.On("GetPhase").Return(v1alpha1.NodePhaseSucceeded)
-		mockN0Status.On("GetBranchStatus").Return(mockN0BranchStatus)
-		mockN0Status.On("IsDirty").Return(false)
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
+		mockN0Status.OnIsDirty().Return(false)
 
 		mockN1Status := &mocks.ExecutableNodeStatus{}
-		mockN1Status.On("GetPhase").Return(v1alpha1.NodePhaseRunning)
-		mockN1Status.On("IsDirty").Return(false)
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
+		mockN1Status.OnIsDirty().Return(false)
 
 		mockWf := &mocks.ExecutableWorkflow{}
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
-		mockWf.On("GetNode", nodeN0).Return(mockN0Node, true)
-		mockWf.On("GetID").Return("w1")
+		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
 		assert.NoError(t, err)

--- a/pkg/controller/nodes/predicate_test.go
+++ b/pkg/controller/nodes/predicate_test.go
@@ -43,6 +43,24 @@ func TestCanExecute(t *testing.T) {
 		assert.Equal(t, PredicatePhaseUndefined, p)
 	})
 
+	t.Run("upstreamNodeNotFound", func(t *testing.T) {
+		// Setup
+		mockN2Status := &mocks.ExecutableNodeStatus{}
+
+		mockNode := &mocks.BaseNode{}
+		mockNode.OnGetID().Return(nodeN2)
+
+		mockWf := &mocks.ExecutableWorkflow{}
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
+		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetID().Return("w1")
+		mockWf.OnGetNode(nodeN0).Return(nil, false)
+
+		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
+		assert.Error(t, err)
+		assert.Equal(t, PredicatePhaseUndefined, p)
+	})
+
 	t.Run("upstreamConnectionsNotReady", func(t *testing.T) {
 		// Setup
 		mockN2Status := &mocks.ExecutableNodeStatus{}
@@ -86,10 +104,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN1Status.OnIsDirty().Return(false)
@@ -99,6 +121,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -115,10 +139,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN1Status.OnIsDirty().Return(false)
@@ -127,6 +155,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
 
 		mockWf.OnGetID().Return("w1")
@@ -145,10 +175,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN1Status.OnIsDirty().Return(true)
@@ -158,6 +192,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -174,10 +210,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
 		mockN1Status.OnIsDirty().Return(false)
@@ -187,6 +227,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -203,10 +245,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
 		mockN1Status.OnIsDirty().Return(false)
@@ -216,6 +262,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -232,10 +280,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
 		mockN1Status.OnIsDirty().Return(false)
@@ -245,6 +297,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -262,10 +316,14 @@ func TestCanExecute(t *testing.T) {
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
 
+		mockN0 := &mocks.ExecutableNode{}
+		mockN0.OnGetBranchNode().Return(nil)
 		mockN0Status := &mocks.ExecutableNodeStatus{}
 		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseFailed)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseFailed)
 		mockN1Status.OnIsDirty().Return(false)
@@ -275,6 +333,8 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -288,6 +348,7 @@ func TestCanExecute(t *testing.T) {
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
 		mockN2Status.OnIsDirty().Return(false)
+		mockN2Status.OnGetParentNodeID().Return(&nodeN0)
 
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
@@ -303,6 +364,8 @@ func TestCanExecute(t *testing.T) {
 		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
 		mockN1Status.OnIsDirty().Return(false)
@@ -313,6 +376,7 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
 		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -326,6 +390,7 @@ func TestCanExecute(t *testing.T) {
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
 		mockN2Status.OnIsDirty().Return(false)
+		mockN2Status.OnGetParentNodeID().Return(&nodeN0)
 
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
@@ -341,6 +406,8 @@ func TestCanExecute(t *testing.T) {
 		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSkipped)
 		mockN1Status.OnIsDirty().Return(false)
@@ -351,6 +418,7 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
 		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
@@ -364,6 +432,7 @@ func TestCanExecute(t *testing.T) {
 		mockN2Status := &mocks.ExecutableNodeStatus{}
 		// No parent node
 		mockN2Status.OnIsDirty().Return(false)
+		mockN2Status.OnGetParentNodeID().Return(&nodeN0)
 
 		mockNode := &mocks.BaseNode{}
 		mockNode.OnGetID().Return(nodeN2)
@@ -379,6 +448,8 @@ func TestCanExecute(t *testing.T) {
 		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
 		mockN0Status.OnIsDirty().Return(false)
 
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
 		mockN1Status := &mocks.ExecutableNodeStatus{}
 		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
 		mockN1Status.OnIsDirty().Return(false)
@@ -389,6 +460,129 @@ func TestCanExecute(t *testing.T) {
 		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
 		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
 		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
+		mockWf.OnGetID().Return("w1")
+
+		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
+		assert.NoError(t, err)
+		assert.Equal(t, PredicatePhaseNotReady, p)
+	})
+
+	t.Run("upstreamConnectionsBranchNotYetEvaluated", func(t *testing.T) {
+		// Setup
+		mockN2Status := &mocks.ExecutableNodeStatus{}
+		// No parent node
+		mockN2Status.OnIsDirty().Return(false)
+		mockN2Status.OnGetParentNodeID().Return(&nodeN0)
+
+		mockNode := &mocks.BaseNode{}
+		mockNode.OnGetID().Return(nodeN2)
+
+		mockN0BranchStatus := &mocks.MutableBranchNodeStatus{}
+		mockN0BranchStatus.OnGetPhase().Return(v1alpha1.BranchNodeNotYetEvaluated)
+
+		mockN0BranchNode := &mocks.ExecutableBranchNode{}
+		mockN0Node := &mocks.ExecutableNode{}
+		mockN0Node.OnGetBranchNode().Return(mockN0BranchNode)
+		mockN0Status := &mocks.ExecutableNodeStatus{}
+		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
+		mockN0Status.OnIsDirty().Return(false)
+
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
+		mockN1Status := &mocks.ExecutableNodeStatus{}
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN1Status.OnIsDirty().Return(false)
+
+		mockWf := &mocks.ExecutableWorkflow{}
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
+		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
+		mockWf.OnGetID().Return("w1")
+
+		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
+		assert.NoError(t, err)
+		assert.Equal(t, PredicatePhaseNotReady, p)
+	})
+
+	t.Run("upstreamConnectionsBranchFailed", func(t *testing.T) {
+		// Setup
+		mockN2Status := &mocks.ExecutableNodeStatus{}
+		// No parent node
+		mockN2Status.OnIsDirty().Return(false)
+		mockN2Status.OnGetParentNodeID().Return(&nodeN0)
+
+		mockNode := &mocks.BaseNode{}
+		mockNode.OnGetID().Return(nodeN2)
+
+		mockN0BranchStatus := &mocks.MutableBranchNodeStatus{}
+		mockN0BranchStatus.OnGetPhase().Return(v1alpha1.BranchNodeError)
+
+		mockN0BranchNode := &mocks.ExecutableBranchNode{}
+		mockN0Node := &mocks.ExecutableNode{}
+		mockN0Node.OnGetBranchNode().Return(mockN0BranchNode)
+		mockN0Status := &mocks.ExecutableNodeStatus{}
+		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
+		mockN0Status.OnIsDirty().Return(false)
+
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
+		mockN1Status := &mocks.ExecutableNodeStatus{}
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN1Status.OnIsDirty().Return(false)
+
+		mockWf := &mocks.ExecutableWorkflow{}
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
+		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
+		mockWf.OnGetID().Return("w1")
+
+		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)
+		assert.NoError(t, err)
+		assert.Equal(t, PredicatePhaseNotReady, p)
+	})
+
+	// ParentNode branch ready
+	t.Run("upstreamConnectionsBranchSuccessBranchNodeRunning", func(t *testing.T) {
+		// Setup
+		mockN2Status := &mocks.ExecutableNodeStatus{}
+		// No parent node
+		mockN2Status.OnIsDirty().Return(false)
+		mockN2Status.OnGetParentNodeID().Return(nil)
+
+		mockNode := &mocks.BaseNode{}
+		mockNode.OnGetID().Return(nodeN2)
+
+		mockN0BranchStatus := &mocks.MutableBranchNodeStatus{}
+		mockN0BranchStatus.OnGetPhase().Return(v1alpha1.BranchNodeSuccess)
+		mockN0BranchNode := &mocks.ExecutableBranchNode{}
+
+		mockN0Node := &mocks.ExecutableNode{}
+		mockN0Node.OnGetBranchNode().Return(mockN0BranchNode)
+		mockN0Status := &mocks.ExecutableNodeStatus{}
+		mockN0Status.OnGetPhase().Return(v1alpha1.NodePhaseRunning)
+		mockN0Status.OnGetBranchStatus().Return(mockN0BranchStatus)
+		mockN0Status.OnIsDirty().Return(false)
+
+		mockN1 := &mocks.ExecutableNode{}
+		mockN1.OnGetBranchNode().Return(nil)
+		mockN1Status := &mocks.ExecutableNodeStatus{}
+		mockN1Status.OnGetPhase().Return(v1alpha1.NodePhaseSucceeded)
+		mockN1Status.OnIsDirty().Return(false)
+
+		mockWf := &mocks.ExecutableWorkflow{}
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN0).Return(mockN0Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN1).Return(mockN1Status)
+		mockWf.OnGetNodeExecutionStatus(ctx, nodeN2).Return(mockN2Status)
+		mockWf.OnToNode(nodeN2).Return(upstreamN2, nil)
+		mockWf.OnGetNode(nodeN0).Return(mockN0Node, true)
+		mockWf.OnGetNode(nodeN1).Return(mockN1, true)
 		mockWf.OnGetID().Return("w1")
 
 		p, err := CanExecute(ctx, mockWf, mockWf, mockNode)


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>
# TL;DR
Downstream nodes of a node, have the parentNodeID always set. For the branch node, the parent node is the branch node of all the branches. When a sub-node of branch is to be executed, it should wait for the branch to be success, but the branch node (as it is the container node) will not be marked as success.
A branch sub-node may also be downstream from a regular node (e.g. start-node). Thus logically it can be executed after this node. But, it should wait for the branch condition to be evaluated and for the node to be ready.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1232

