### PR TITLE
Construct subnode DataDir to be under parent's node OutputDir to keep behavior consistent across

### DIFF
--- a/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -523,7 +523,7 @@ func (in *NodeStatus) GetNodeExecutionStatus(ctx context.Context, id NodeID) Exe
 		n.SetParentTaskID(in.GetParentTaskID())
 		n.DataReferenceConstructor = in.DataReferenceConstructor
 		if len(n.GetDataDir()) == 0 {
-			dataDir, err := in.DataReferenceConstructor.ConstructReference(ctx, in.GetDataDir(), id)
+			dataDir, err := in.DataReferenceConstructor.ConstructReference(ctx, in.GetOutputDir(), id)
 			if err != nil {
 				logger.Errorf(ctx, "Failed to construct data dir for node [%v]", id)
 				return n

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -552,9 +552,10 @@ func (in *NodeStatus) GetNodeExecutionStatus(ctx context.Context, id NodeID) Exe
 	newNodeStatus := &NodeStatus{
 		MutableStruct: MutableStruct{},
 	}
+
 	newNodeStatus.SetParentTaskID(in.GetParentTaskID())
 	newNodeStatus.SetParentNodeID(in.GetParentNodeID())
-	dataDir, err := in.DataReferenceConstructor.ConstructReference(ctx, in.GetDataDir(), id)
+	dataDir, err := in.DataReferenceConstructor.ConstructReference(ctx, in.GetOutputDir(), id)
 	if err != nil {
 		logger.Errorf(ctx, "Failed to construct data dir for node [%v]", id)
 		return n


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
When constructing a node status, the `DataDir` was incorrectly set to be a child of the parent's `DataDir` when it should have been a child of the parent's `OutputDir`.

This, incidentally, only broke in the case of Dynamic Workflow caching because in all other cases we explicitly set the data directory (essentially overriding the bad value retrieved from `GetNodeExecutionStatus`).

Further cleanup/refactor is needed to avoid having multiple branches of the code that set up data dir differently.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1238