### PR TITLE
Use PluginCleanupPolicy from flyteorg/flyteplugins#203

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.21.0
-	github.com/flyteorg/flyteplugins v0.6.0
+	github.com/flyteorg/flyteplugins v0.6.1
 	github.com/flyteorg/flytestdlib v0.3.34
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flyteorg/flyteidl v0.21.0 h1:AwHNusfxJMfRRSDk2QWfb3aIlyLJrFWVGtpXCbCtJ5A=
 github.com/flyteorg/flyteidl v0.21.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
-github.com/flyteorg/flyteplugins v0.6.0 h1:eoMmqJIw3K+J4JWokDcd4Y1YGLiicE6p5vEYhOUHZ4s=
-github.com/flyteorg/flyteplugins v0.6.0/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
+github.com/flyteorg/flyteplugins v0.6.1 h1:Mq9uM/IN6fXHo03NlXSa+to2GHEom2NAcRWlr+bVH6g=
+github.com/flyteorg/flyteplugins v0.6.1/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
 github.com/flyteorg/flytestdlib v0.3.34 h1:OOuV03X8c1AWInzBU6IRsqpEF6y8WDJngbPcdL4VktY=

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -337,32 +337,38 @@ func (e PluginManager) Abort(ctx context.Context, tCtx pluginsCore.TaskExecution
 
 	deleteResource := true
 	abortOverride, hasAbortOverride := e.plugin.(k8s.PluginAbortOverride)
+
+	resourceToFinalize := o
 	var behavior k8s.AbortBehavior
+
 	if hasAbortOverride {
 		behavior, err = abortOverride.OnAbort(ctx, tCtx, o)
 		deleteResource = err == nil && behavior.DeleteResource
+		if err == nil && behavior.Resource != nil {
+			resourceToFinalize = behavior.Resource
+		}
 	}
 
 	if err != nil {
 	} else if deleteResource {
-		err = e.kubeClient.GetClient().Delete(ctx, o)
+		err = e.kubeClient.GetClient().Delete(ctx, resourceToFinalize)
 	} else {
 		if behavior.Patch != nil && behavior.Update == nil {
-			err = e.kubeClient.GetClient().Patch(ctx, o, behavior.Patch.Patch, behavior.Patch.Options...)
-		} else if behavior.Update != nil {
-			err = e.kubeClient.GetClient().Update(ctx, o, behavior.Update.Options...)
+			err = e.kubeClient.GetClient().Patch(ctx, resourceToFinalize, behavior.Patch.Patch, behavior.Patch.Options...)
+		} else if behavior.Patch == nil && behavior.Update != nil {
+			err = e.kubeClient.GetClient().Update(ctx, resourceToFinalize, behavior.Update.Options...)
 		} else {
-			err = errors.Errorf(errors.RuntimeFailure, "AbortBehavior for resource %v must specify either a Patch and an Update operation if Delete is set to false. Only one can be supplied.", o.GetName())
+			err = errors.Errorf(errors.RuntimeFailure, "AbortBehavior for resource %v must specify either a Patch and an Update operation if Delete is set to false. Only one can be supplied.", resourceToFinalize.GetName())
 		}
 		if behavior.DeleteOnErr && err != nil {
-			logger.Warningf(ctx, "Failed to apply AbortBehavior for resource %v with error %v. Will attempt to delete resource.", o.GetName(), err)
-			err = e.kubeClient.GetClient().Delete(ctx, o)
+			logger.Warningf(ctx, "Failed to apply AbortBehavior for resource %v with error %v. Will attempt to delete resource.", resourceToFinalize.GetName(), err)
+			err = e.kubeClient.GetClient().Delete(ctx, resourceToFinalize)
 		}
 	}
 
 	if err != nil && !IsK8sObjectNotExists(err) {
 		logger.Warningf(ctx, "Failed to clear finalizers for Resource with name: %v/%v. Error: %v",
-			o.GetNamespace(), o.GetName(), err)
+			resourceToFinalize.GetNamespace(), resourceToFinalize.GetName(), err)
 		return err
 	}
 

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -444,6 +444,9 @@ func TestPluginManager_Abort(t *testing.T) {
 
 		err = pluginManager.Abort(ctx, tctx)
 		assert.NoError(t, err)
+
+		// no custom cleanup policy has been specified
+		mockResourceHandler.AssertNumberOfCalls(t, "OnAbort", 0)
 	})
 
 	t.Run("Abort Pod doesn't exist", func(t *testing.T) {

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -485,7 +485,7 @@ func TestPluginManager_Abort(t *testing.T) {
 		pluginResource := &v1.Pod{}
 
 		abortBehavior := k8s.AbortBehaviorPatchDefaultResource(k8s.PatchResourceOperation{
-			Patch: nil,
+			Patch:   nil,
 			Options: nil,
 		}, false)
 


### PR DESCRIPTION
# TL;DR
Per discussion in `#feature-discussions` Slack channel, I'm opening this as a draft PR as to center discussions related to flyteorg/flyte#1345.

This PR applies the `PluginCleanupPolicy` interface from flyteorg/flyteplugins#203, if applicable, instead of defaulting to just deleting the resource when the task is aborted.

this will need to be updated once the flyteplugins changed is merged & its version is bumped in `go.mod`.

cc @regadas , @EngHabu , @kumare3 :)

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [x] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
