### PR TITLE
Update logs to make resource quantities readable

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flyteorg/flyteidl v0.19.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteidl v0.19.19 h1:jv93YLz0Bq++sH9r0AOhdNaHFdXSCWjsXJoLOIduA2o=
 github.com/flyteorg/flyteidl v0.19.19/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
-github.com/flyteorg/flyteplugins v0.5.62 h1:AkoBjPGWisJRG8q8lxMe+BVQ/ev4u2t5R1DQvE/pvTw=
-github.com/flyteorg/flyteplugins v0.5.62/go.mod h1:nesnW7pJhXEysFQg9TnSp36ao33ie0oA/TI4sYPaeyw=
 github.com/flyteorg/flyteplugins v0.5.63 h1:ntRSrewd4nH9og1BVtOoNo448T14sDlztNj3POFnEW0=
 github.com/flyteorg/flyteplugins v0.5.63/go.mod h1:nesnW7pJhXEysFQg9TnSp36ao33ie0oA/TI4sYPaeyw=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -169,8 +169,13 @@ func (e *PluginManager) getPodEffectiveResourceLimits(ctx context.Context, pod *
 		}
 	}
 
-	logger.Infof(ctx, "The resource requirement for creating Pod [%v/%v] is [%v]\n",
-		pod.Namespace, pod.Name, podRequestedResources)
+	formattedResources := make([]string, 0, len(podRequestedResources))
+	for resourceName, quantity := range podRequestedResources {
+		formattedResources = append(formattedResources, fmt.Sprintf("{[%v]: [%v]}", resourceName, quantity.String()))
+	}
+
+	logger.Infof(ctx, "The resource requirement for creating Pod [%v/%v] is [%+v]\n",
+		pod.Namespace, pod.Name, formattedResources)
 
 	return podRequestedResources
 }


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
A small change to how we log resource quantities to make them more readable.

Before the fix:
```
The resource requirement for creating Pod [cluster-deploy-development/c27it8qgli-n0-0] is [map[cpu:{{1 0} {\u003cnil\u003e}  DecimalSI} memory:{{524288000 0} {\u003cnil\u003e}  BinarySI}]]
```

After the fix:
```
The resource requirement for creating Pod [cluster-deploy-development/zvkuworvzn-n0-0] is [[{[cpu]: [1]} {[memory]: [500Mi]}]]
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin