### PR TITLE
Start-Node Output file copied to output result

### DIFF
--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1641,6 +1641,47 @@ func TestNodeExecutor_FinalizeHandler(t *testing.T) {
 		assert.NoError(t, exec.FinalizeHandler(ctx, nil, nil, nl, n))
 	})
 }
+func TestNodeExecutionEventStartNode(t *testing.T) {
+	execID := &core.WorkflowExecutionIdentifier{
+		Name:    "e1",
+		Domain:  "d1",
+		Project: "p1",
+	}
+	nID := &core.NodeExecutionIdentifier{
+		NodeId:      "start-node",
+		ExecutionId: execID,
+	}
+	tID := &core.TaskExecutionIdentifier{
+		NodeExecutionId: nID,
+	}
+	p := handler.PhaseInfoQueued("r")
+	inputReader := &mocks3.InputReader{}
+	inputReader.OnGetInputPath().Return("reference")
+	parentInfo := &mocks4.ImmutableParentInfo{}
+	parentInfo.OnGetUniqueID().Return("np1")
+	parentInfo.OnCurrentAttempt().Return(uint32(2))
+
+	id := "id"
+	n := &mocks.ExecutableNode{}
+	n.OnGetID().Return(id)
+	n.OnGetName().Return("name")
+	nl := &mocks4.NodeLookup{}
+	ns := &mocks.ExecutableNodeStatus{}
+	ns.OnGetPhase().Return(v1alpha1.NodePhaseNotYetStarted)
+	nl.OnGetNodeExecutionStatusMatch(mock.Anything, id).Return(ns)
+	ns.OnGetParentTaskID().Return(tID)
+	ns.OnGetOutputDirMatch(mock.Anything).Return("dummy://dummyOutUrl")
+	ev, err := ToNodeExecutionEvent(nID, p, inputReader, ns, v1alpha1.EventVersion0, parentInfo, n)
+	assert.NoError(t, err)
+	assert.Equal(t, "start-node", ev.Id.NodeId)
+	assert.Equal(t, execID, ev.Id.ExecutionId)
+	assert.Empty(t, ev.SpecNodeId)
+	assert.Nil(t, ev.ParentNodeMetadata)
+	assert.Equal(t, tID, ev.ParentTaskMetadata.Id)
+	assert.Empty(t, ev.NodeName)
+	assert.Empty(t, ev.RetryGroup)
+	assert.Equal(t, ev.OutputResult.(*event.NodeExecutionEvent_OutputUri).OutputUri, ev.InputUri)
+}
 
 func TestNodeExecutionEventV0(t *testing.T) {
 	execID := &core.WorkflowExecutionIdentifier{

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1671,7 +1671,7 @@ func TestNodeExecutionEventStartNode(t *testing.T) {
 	nl.OnGetNodeExecutionStatusMatch(mock.Anything, id).Return(ns)
 	ns.OnGetParentTaskID().Return(tID)
 	ns.OnGetOutputDirMatch(mock.Anything).Return("dummy://dummyOutUrl")
-	ev, err := ToNodeExecutionEvent(nID, p, inputReader, ns, v1alpha1.EventVersion0, parentInfo, n)
+	ev, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion0, parentInfo, n)
 	assert.NoError(t, err)
 	assert.Equal(t, "start-node", ev.Id.NodeId)
 	assert.Equal(t, execID, ev.Id.ExecutionId)

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1680,7 +1680,8 @@ func TestNodeExecutionEventStartNode(t *testing.T) {
 	assert.Equal(t, tID, ev.ParentTaskMetadata.Id)
 	assert.Empty(t, ev.NodeName)
 	assert.Empty(t, ev.RetryGroup)
-	assert.Equal(t, ev.OutputResult.(*event.NodeExecutionEvent_OutputUri).OutputUri, ev.InputUri)
+	assert.Equal(t, "dummy://dummyOutUrl/outputs.pb",
+		ev.OutputResult.(*event.NodeExecutionEvent_OutputUri).OutputUri)
 }
 
 func TestNodeExecutionEventV0(t *testing.T) {

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -95,14 +95,13 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	}
 
 	var nev *event.NodeExecutionEvent
-	// Start node is special case where the Inputs and Outputs are the same and hence here we copy the Output info
-	// in both the InputUri and OutputUri
+	// Start node is special case where the Inputs and Outputs are the same and hence here we copy the Output file
+	// into the OutputResult and in admin we copy it over into input aswell.
 	if nodeExecID.NodeId == v1alpha1.StartNodeID {
 		outputsFile := v1alpha1.GetOutputsFile(status.GetOutputDir())
 		nev = &event.NodeExecutionEvent{
 			Id:       nodeExecID,
 			Phase:    phase,
-			InputUri: outputsFile.String(),
 			OutputResult: ToNodeExecOutput(&handler.OutputInfo{
 				OutputURI: outputsFile,
 			}),

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -100,8 +100,8 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	if nodeExecID.NodeId == v1alpha1.StartNodeID {
 		outputsFile := v1alpha1.GetOutputsFile(status.GetOutputDir())
 		nev = &event.NodeExecutionEvent{
-			Id:       nodeExecID,
-			Phase:    phase,
+			Id:    nodeExecID,
+			Phase: phase,
 			OutputResult: ToNodeExecOutput(&handler.OutputInfo{
 				OutputURI: outputsFile,
 			}),

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -94,11 +94,24 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 		phase = core.NodeExecution_RUNNING
 	}
 
-	nev := &event.NodeExecutionEvent{
-		Id:         nodeExecID,
-		Phase:      phase,
-		InputUri:   inputPath,
-		OccurredAt: occurredTime,
+	var nev *event.NodeExecutionEvent
+	if nodeExecID.NodeId == v1alpha1.StartNodeID {
+		nev = &event.NodeExecutionEvent{
+			Id:       nodeExecID,
+			Phase:    ToNodeExecEventPhase(info.GetPhase()),
+			InputUri: v1alpha1.GetOutputsFile(status.GetOutputDir()).String(),
+			OutputResult: ToNodeExecOutput(&handler.OutputInfo{
+				OutputURI: v1alpha1.GetOutputsFile(status.GetOutputDir()),
+			}),
+			OccurredAt: occurredTime,
+		}
+	} else {
+		nev = &event.NodeExecutionEvent{
+			Id:         nodeExecID,
+			Phase:      ToNodeExecEventPhase(info.GetPhase()),
+			InputUri:   inputPath,
+			OccurredAt: occurredTime,
+		}
 	}
 
 	if eventVersion == v1alpha1.EventVersion0 && status.GetParentTaskID() != nil {

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -98,7 +98,7 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	if nodeExecID.NodeId == v1alpha1.StartNodeID {
 		nev = &event.NodeExecutionEvent{
 			Id:       nodeExecID,
-			Phase:    ToNodeExecEventPhase(info.GetPhase()),
+			Phase:    phase,
 			InputUri: v1alpha1.GetOutputsFile(status.GetOutputDir()).String(),
 			OutputResult: ToNodeExecOutput(&handler.OutputInfo{
 				OutputURI: v1alpha1.GetOutputsFile(status.GetOutputDir()),
@@ -108,7 +108,7 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	} else {
 		nev = &event.NodeExecutionEvent{
 			Id:         nodeExecID,
-			Phase:      ToNodeExecEventPhase(info.GetPhase()),
+			Phase:      phase,
 			InputUri:   inputPath,
 			OccurredAt: occurredTime,
 		}

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -95,13 +95,16 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	}
 
 	var nev *event.NodeExecutionEvent
+	// Start node is special case where the Inputs and Outputs are the same and hence here we copy the Output info
+	// in both the InputUri and OutputUri
 	if nodeExecID.NodeId == v1alpha1.StartNodeID {
+		outputsFile := v1alpha1.GetOutputsFile(status.GetOutputDir())
 		nev = &event.NodeExecutionEvent{
 			Id:       nodeExecID,
 			Phase:    phase,
-			InputUri: v1alpha1.GetOutputsFile(status.GetOutputDir()).String(),
+			InputUri: outputsFile.String(),
 			OutputResult: ToNodeExecOutput(&handler.OutputInfo{
-				OutputURI: v1alpha1.GetOutputsFile(status.GetOutputDir()),
+				OutputURI: outputsFile,
 			}),
 			OccurredAt: occurredTime,
 		}


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
The node data returned for start-node is currently incorrect from admin and this is due to the fact that propeller is sending non existent inputUri for  start-node

Flytekit gets around this issue by skipping the call to admin altogether and similar fix was done in flytectl 
https://github.com/flyteorg/flytekit/blob/master/flytekit/clis/flyte_cli/main.py#L1540

This is an attempt to fix the issue in propeller.
For start-node the Input and Output data is the same and hence using this fact we send the node event from propeller.


After the fix 
```
[
	{
		"node_exec": {
			"id": {
				"nodeId": "start-node",
				"executionId": {
					"project": "flytesnacks",
					"domain": "development",
					"name": "fdbbaa49c298c4bb48ad"
				}
			},
			"closure": {
				"outputUri": "s3://my-s3-bucket/metadata/propeller/sandbox/flytesnacks-development-fdbbaa49c298c4bb48ad/start-node/data/0/outputs.pb",
				"phase": "SUCCEEDED",
				"createdAt": "2021-09-14T11:51:04.355307Z",
				"updatedAt": "2021-09-14T11:51:04.355307Z"
			},
			"metadata": {
				"specNodeId": "start-node"
			}
		},
		"outputs": {
			"am": true,
			"day_of_week": "Sunday",
			"number": 5
		}
	}
]
```


## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1221

## Follow-up issue
_NA_
