### PR TITLE
gracefully failing workflow on ExecutionNotFound error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DiSiqueira/GoTree v1.0.1-0.20180907134536-53a8e837f295
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
-	github.com/flyteorg/flyteidl v0.19.22
+	github.com/flyteorg/flyteidl v0.21.1
 	github.com/flyteorg/flyteplugins v0.5.72
 	github.com/flyteorg/flytestdlib v0.3.34
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flyteorg/flyteidl v0.19.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteidl v0.19.22 h1:e3M0Dob/r5n+AJfAByzad/svMAVes7XfZVxUNCi6AeQ=
 github.com/flyteorg/flyteidl v0.19.22/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.21.1 h1:wINIuKv+0xtTD0kR2RF99C5uGYuwflhY78iw+DkiY8o=
+github.com/flyteorg/flyteidl v0.21.1/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.5.72 h1:mtbpn4nuFrhZ2DadUlLxjK2RQ9FBFqDf0LaXVpe2hyY=
 github.com/flyteorg/flyteplugins v0.5.72/go.mod h1:YjahYP+i4/Qn+dFvxMOGbhDtkQT4EiH4Kb88KNK505A=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -230,9 +230,9 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 			}
 		}
 
-		// ExecutionNotFound error is returned when flyteadmin is missing the workflow. This is not a valid state
-		// unless we are experiencing a race condition where the workflow has not yet been inserted
-		// into the db (ie. workflow phase is WorkflowPhaseReady).
+		// ExecutionNotFound error is returned when flyteadmin is missing the workflow. This is not
+		// a valid state unless we are experiencing a race condition where the workflow has not yet
+		// been inserted into the db (ie. workflow phase is WorkflowPhaseReady).
 		if err != nil {
 			e, ok := err.(*errors.WorkflowErrorWithCause)
 			if ok && eventsErr.IsNotFound(e.Cause()) && w.GetExecutionStatus().GetPhase() != v1alpha1.WorkflowPhaseReady {

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	eventsErr "github.com/flyteorg/flyteidl/clients/go/events/errors"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
 	"github.com/flyteorg/flytestdlib/contextutils"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flytepropeller/pkg/controller/workflow/errors"
 	"github.com/flyteorg/flytepropeller/pkg/controller/workflowstore"
 
 	"github.com/flyteorg/flytestdlib/logger"
@@ -227,6 +229,31 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 				ResetFinalizers(mutatedWf)
 			}
 		}
+
+		// ExecutionNotFound error is returned when flyteadmin is missing the workflow. This is not a valid state
+		// unless we are experiencing a race condition where the workflow has not yet been inserted
+		// into the db (ie. workflow phase is WorkflowPhaseReady).
+		if err != nil {
+			e, ok := err.(*errors.WorkflowErrorWithCause)
+			if ok && eventsErr.IsNotFound(e.Cause()) && w.GetExecutionStatus().GetPhase() != v1alpha1.WorkflowPhaseReady {
+				t.Stop()
+				logger.Errorf(ctx, "Failed to process workflow, failing: %s", e.Cause())
+
+				// We set the workflow status to failing to abort any active tasks in the next round.
+				mutableW := w.DeepCopy()
+				mutableW.Status.UpdatePhase(v1alpha1.WorkflowPhaseFailing, "Workflow execution is missing in flyteadmin, aborting", &core.ExecutionError{
+					Kind:    core.ExecutionError_SYSTEM,
+					Code:    "ExecutionNotFound",
+					Message: "Workflow execution not found in flyteadmin.",
+				})
+				if _, e := p.wfStore.Update(ctx, mutableW, workflowstore.PriorityClassCritical); e != nil {
+					logger.Errorf(ctx, "Failed to record an ExecutionNotFound workflow as failed, reason: %s. Retrying...", e)
+					return e
+				}
+				return nil
+			}
+		}
+
 		// TODO we will need to call updatestatus when it is supported. But to preserve metadata like (label/finalizer) we will need to use update
 
 		// update the GetExecutionStatus block of the FlyteWorkflow resource. UpdateStatus will not

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"runtime/debug"
@@ -233,7 +232,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 		// ExecutionNotFound error is returned when flyteadmin is missing the workflow. This is not
 		// a valid state unless we are experiencing a race condition where the workflow has not yet
 		// been inserted into the db (ie. workflow phase is WorkflowPhaseReady).
-		if err != nil && errors.Is(err, &eventsErr.EventError{Code: eventsErr.ExecutionNotFound}) && w.GetExecutionStatus().GetPhase() != v1alpha1.WorkflowPhaseReady {
+		if err != nil && eventsErr.IsNotFound(err) && w.GetExecutionStatus().GetPhase() != v1alpha1.WorkflowPhaseReady {
 			t.Stop()
 			logger.Errorf(ctx, "Failed to process workflow, failing: %s", err)
 

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	eventErrors "github.com/flyteorg/flyteidl/clients/go/events/errors"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flytepropeller/pkg/controller/config"
-	"github.com/flyteorg/flytepropeller/pkg/controller/workflowstore"
 	workflowErrors "github.com/flyteorg/flytepropeller/pkg/controller/workflow/errors"
+	"github.com/flyteorg/flytepropeller/pkg/controller/workflowstore"
 
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
@@ -466,8 +466,8 @@ func TestPropeller_Handle(t *testing.T) {
 	t.Run("failOnExecutionNotFoundError", func(t *testing.T) {
 		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
 			ObjectMeta: v1.ObjectMeta{
-				Name:       name,
-				Namespace:  namespace,
+				Name:      name,
+				Namespace: namespace,
 			},
 			WorkflowSpec: &v1alpha1.WorkflowSpec{
 				ID: "w1",
@@ -479,9 +479,9 @@ func TestPropeller_Handle(t *testing.T) {
 		}))
 		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
 			return workflowErrors.Wrapf(workflowErrors.EventRecordingError, "",
-				&eventErrors.EventError {
-					Code: eventErrors.ExecutionNotFound,
-					Cause: nil,
+				&eventErrors.EventError{
+					Code:    eventErrors.ExecutionNotFound,
+					Cause:   nil,
 					Message: "The execution that the event belongs to does not exist",
 				}, "failed to transition phase")
 		}

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	eventErrors "github.com/flyteorg/flyteidl/clients/go/events/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/flyteorg/flytepropeller/pkg/controller/config"
 	"github.com/flyteorg/flytepropeller/pkg/controller/workflowstore"
+	workflowErrors "github.com/flyteorg/flytepropeller/pkg/controller/workflow/errors"
 
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
@@ -459,6 +461,37 @@ func TestPropeller_Handle(t *testing.T) {
 		assert.Equal(t, v1alpha1.WorkflowPhaseFailed, r.GetExecutionStatus().GetPhase())
 		assert.Equal(t, 0, len(r.Finalizers))
 		assert.True(t, HasCompletedLabel(r))
+	})
+
+	t.Run("failOnExecutionNotFoundError", func(t *testing.T) {
+		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
+			ObjectMeta: v1.ObjectMeta{
+				Name:       name,
+				Namespace:  namespace,
+			},
+			WorkflowSpec: &v1alpha1.WorkflowSpec{
+				ID: "w1",
+			},
+			Status: v1alpha1.WorkflowStatus{
+				Phase:          v1alpha1.WorkflowPhaseRunning,
+				FailedAttempts: 0,
+			},
+		}))
+		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
+			return workflowErrors.Wrapf(workflowErrors.EventRecordingError, "",
+				&eventErrors.EventError {
+					Code: eventErrors.ExecutionNotFound,
+					Cause: nil,
+					Message: "The execution that the event belongs to does not exist",
+				}, "failed to transition phase")
+		}
+		assert.NoError(t, p.Handle(ctx, namespace, name))
+
+		r, err := s.Get(ctx, namespace, name)
+		assert.NoError(t, err)
+		assert.Equal(t, v1alpha1.WorkflowPhaseFailing, r.GetExecutionStatus().GetPhase())
+		assert.Equal(t, 0, len(r.Finalizers))
+		assert.False(t, HasCompletedLabel(r))
 	})
 }
 

--- a/pkg/controller/nodes/errors/errors.go
+++ b/pkg/controller/nodes/errors/errors.go
@@ -28,6 +28,12 @@ func (n *NodeError) Is(target error) bool {
 	if !ok {
 		return false
 	}
+	if n == nil && t == nil {
+		return true
+	}
+	if n == nil || t == nil {
+		return false
+	}
 	return n.ErrCode == t.ErrCode && (n.Message == t.Message || t.Message == "") && (n.Node == t.Node || t.Node == "")
 }
 
@@ -65,6 +71,12 @@ func (n *NodeErrorWithCause) Error() string {
 func (n *NodeErrorWithCause) Is(target error) bool {
 	t, ok := target.(*NodeErrorWithCause)
 	if !ok {
+		return false
+	}
+	if n == nil && t == nil {
+		return true
+	}
+	if n == nil || t == nil {
 		return false
 	}
 	return n.Is(target) && (n.cause == t.cause || t.cause == nil)

--- a/pkg/controller/nodes/errors/errors.go
+++ b/pkg/controller/nodes/errors/errors.go
@@ -23,9 +23,21 @@ func (n *NodeError) Error() string {
 	return fmt.Sprintf("failed at Node[%s]. %v: %v", n.Node, n.ErrCode, n.Message)
 }
 
+func (n *NodeError) Is(target error) bool {
+	t, ok := target.(*NodeError)
+	if !ok {
+		return false
+	}
+	return n.ErrCode == t.ErrCode && (n.Message == t.Message || t.Message == "") && (n.Node == t.Node || t.Node == "")
+}
+
 type NodeErrorWithCause struct {
 	NodeError error
 	cause     error
+}
+
+func (n *NodeErrorWithCause) Cause() error {
+	return n.cause
 }
 
 func (n *NodeErrorWithCause) Code() ErrorCode {
@@ -50,7 +62,15 @@ func (n *NodeErrorWithCause) Error() string {
 	return fmt.Sprintf("%v, caused by: %v", nodeError, cause)
 }
 
-func (n *NodeErrorWithCause) Cause() error {
+func (n *NodeErrorWithCause) Is(target error) bool {
+	t, ok := target.(*NodeErrorWithCause)
+	if !ok {
+		return false
+	}
+	return n.Is(target) && (n.cause == t.cause || t.cause == nil)
+}
+
+func (n *NodeErrorWithCause) Unwrap() error {
 	return n.cause
 }
 

--- a/pkg/controller/workflow/errors/errors.go
+++ b/pkg/controller/workflow/errors/errors.go
@@ -21,16 +21,36 @@ func (w *WorkflowError) Error() string {
 	return fmt.Sprintf("Workflow[%s] failed. %v: %v", w.Workflow, w.Code, w.Message)
 }
 
+func (w *WorkflowError) Is(target error) bool {
+	t, ok := target.(*WorkflowError)
+	if !ok {
+		return false
+	}
+	return w.Code == t.Code
+}
+
 type WorkflowErrorWithCause struct {
 	*WorkflowError
 	cause error
+}
+
+func (w *WorkflowErrorWithCause) Cause() error {
+	return w.cause
 }
 
 func (w *WorkflowErrorWithCause) Error() string {
 	return fmt.Sprintf("%v, caused by: %v", w.WorkflowError.Error(), w.cause)
 }
 
-func (w *WorkflowErrorWithCause) Cause() error {
+func (w *WorkflowErrorWithCause) Is(target error) bool {
+	t, ok := target.(*WorkflowErrorWithCause)
+	if !ok {
+		return false
+	}
+	return w.Code == t.Code && (w.cause == t.cause || t.cause == nil) && (w.Message == t.Message || t.Message == "") && (w.Workflow == t.Workflow || t.Workflow == "")
+}
+
+func (w *WorkflowErrorWithCause) Unwrap() error {
 	return w.cause
 }
 

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -404,11 +404,10 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 		if err != nil {
 			return err
 		}
-		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus); err != nil {
-			// Ignore ExecutionNotFound error to allow graceful failure
-			if err != nil && !eventsErr.IsNotFound(err) {
-				return err
-			}
+		err = c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus)
+		// Ignore ExecutionNotFound error to allow graceful failure
+		if err != nil && !eventsErr.IsNotFound(err) {
+			return err
 		}
 		c.k8sRecorder.Event(w, corev1.EventTypeWarning, v1alpha1.WorkflowPhaseFailed.String(), "Workflow failed.")
 		return nil
@@ -417,7 +416,9 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 		if err != nil {
 			return err
 		}
-		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus); err != nil {
+		err = c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus)
+		// Ignore ExecutionNotFound error to allow graceful failure
+		if err != nil && !eventsErr.IsNotFound(err) {
 			return err
 		}
 		c.k8sRecorder.Event(w, corev1.EventTypeWarning, v1alpha1.WorkflowPhaseFailed.String(), "Workflow failed.")

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 
 	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flytepropeller/pkg/controller/executors"
-	"github.com/flyteorg/flytepropeller/pkg/controller/workflow/errors"
+	workflowErr "github.com/flyteorg/flytepropeller/pkg/controller/workflow/errors"
 	"github.com/flyteorg/flytepropeller/pkg/utils"
 )
 
@@ -86,7 +87,7 @@ func (c *workflowExecutor) handleReadyWorkflow(ctx context.Context, w *v1alpha1.
 	if startNode == nil {
 		return StatusFailing(&core.ExecutionError{
 			Kind:    core.ExecutionError_SYSTEM,
-			Code:    errors.BadSpecificationError.String(),
+			Code:    workflowErr.BadSpecificationError.String(),
 			Message: "StartNode not found."}), nil
 	}
 
@@ -140,7 +141,7 @@ func (c *workflowExecutor) handleRunningWorkflow(ctx context.Context, w *v1alpha
 	if startNode == nil {
 		return StatusFailing(&core.ExecutionError{
 			Kind:    core.ExecutionError_SYSTEM,
-			Code:    errors.IllegalStateError.String(),
+			Code:    workflowErr.IllegalStateError.String(),
 			Message: "Start node not found"}), nil
 	}
 	execcontext := executors.NewExecutionContext(w, w, w, nil, executors.InitializeControlFlow())
@@ -244,7 +245,7 @@ func convertToExecutionError(err *core.ExecutionError, alternateErr *core.Execut
 			err = alternateErr
 		} else {
 			err = &core.ExecutionError{
-				Code:    errors.RuntimeExecutionError.String(),
+				Code:    workflowErr.RuntimeExecutionError.String(),
 				Message: "Unknown error",
 				Kind:    core.ExecutionError_UNKNOWN,
 			}
@@ -325,7 +326,7 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 			wStatus.UpdatePhase(v1alpha1.WorkflowPhaseAborted, "", nil)
 			wfEvent.OccurredAt = utils.GetProtoTime(wStatus.GetStoppedAt())
 		default:
-			return errors.Errorf(errors.IllegalStateError, "", "Illegal transition from [%v] -> [%v]", wStatus.GetPhase().String(), toStatus.TransitionToPhase.String())
+			return workflowErr.Errorf(workflowErr.IllegalStateError, "", "Illegal transition from [%v] -> [%v]", wStatus.GetPhase().String(), toStatus.TransitionToPhase.String())
 		}
 
 		if recordingErr := c.IdempotentReportEvent(ctx, wfEvent); recordingErr != nil {
@@ -341,7 +342,7 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 				return nil
 			}
 			logger.Warningf(ctx, "Event recording failed. Error [%s]", recordingErr.Error())
-			return errors.Wrapf(errors.EventRecordingError, "", recordingErr, "failed to publish event")
+			return workflowErr.Wrapf(workflowErr.EventRecordingError, "", recordingErr, "failed to publish event")
 		}
 	}
 	return nil
@@ -406,8 +407,7 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 		}
 		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus); err != nil {
 			// Ignore ExecutionNotFound error to allow graceful failure
-			e, ok := err.(*errors.WorkflowErrorWithCause)
-			if !ok && eventsErr.IsNotFound(e.Cause()) {
+			if err != nil && !errors.Is(err, &eventsErr.EventError{Code: eventsErr.ExecutionNotFound}) {
 				return err
 			}
 		}
@@ -424,7 +424,7 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 		c.k8sRecorder.Event(w, corev1.EventTypeWarning, v1alpha1.WorkflowPhaseFailed.String(), "Workflow failed.")
 		return nil
 	default:
-		return errors.Errorf(errors.IllegalStateError, w.ID, "Unsupported state [%s] for workflow", w.GetExecutionStatus().GetPhase().String())
+		return workflowErr.Errorf(workflowErr.IllegalStateError, w.ID, "Unsupported state [%s] for workflow", w.GetExecutionStatus().GetPhase().String())
 	}
 }
 
@@ -449,7 +449,7 @@ func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha
 		}
 
 		if w.Status.FailedAttempts > maxRetries {
-			err = errors.Errorf(errors.RuntimeExecutionError, w.GetID(), "max number of system retry attempts [%d/%d] exhausted. Last known status message: %v", w.Status.FailedAttempts, maxRetries, w.Status.Message)
+			err = workflowErr.Errorf(workflowErr.RuntimeExecutionError, w.GetID(), "max number of system retry attempts [%d/%d] exhausted. Last known status message: %v", w.Status.FailedAttempts, maxRetries, w.Status.Message)
 		}
 
 		var status Status
@@ -477,12 +477,12 @@ func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha
 func (c *workflowExecutor) cleanupRunningNodes(ctx context.Context, w v1alpha1.ExecutableWorkflow, reason string) error {
 	startNode := w.StartNode()
 	if startNode == nil {
-		return errors.Errorf(errors.IllegalStateError, w.GetID(), "StartNode not found in running workflow?")
+		return workflowErr.Errorf(workflowErr.IllegalStateError, w.GetID(), "StartNode not found in running workflow?")
 	}
 
 	execcontext := executors.NewExecutionContext(w, w, w, nil, executors.InitializeControlFlow())
 	if err := c.nodeExecutor.AbortHandler(ctx, execcontext, w, w, startNode, reason); err != nil {
-		return errors.Errorf(errors.CausedByError, w.GetID(), "Failed to propagate Abort for workflow. Error: %v", err)
+		return workflowErr.Errorf(workflowErr.CausedByError, w.GetID(), "Failed to propagate Abort for workflow. Error: %v", err)
 	}
 
 	return nil

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -404,10 +404,10 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 		if err != nil {
 			return err
 		}
-		err = c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus)
+		failingErr := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus)
 		// Ignore ExecutionNotFound error to allow graceful failure
-		if err != nil && !eventsErr.IsNotFound(err) {
-			return err
+		if failingErr != nil && !eventsErr.IsNotFound(failingErr) {
+			return failingErr
 		}
 		c.k8sRecorder.Event(w, corev1.EventTypeWarning, v1alpha1.WorkflowPhaseFailed.String(), "Workflow failed.")
 		return nil
@@ -416,10 +416,10 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 		if err != nil {
 			return err
 		}
-		err = c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus)
+		failureErr := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, wStatus, newStatus)
 		// Ignore ExecutionNotFound error to allow graceful failure
-		if err != nil && !eventsErr.IsNotFound(err) {
-			return err
+		if failureErr != nil && !eventsErr.IsNotFound(failureErr) {
+			return failureErr
 		}
 		c.k8sRecorder.Event(w, corev1.EventTypeWarning, v1alpha1.WorkflowPhaseFailed.String(), "Workflow failed.")
 		return nil


### PR DESCRIPTION
Signed-off-by: Daniel Rammer <daniel@union.ai>

# TL;DR
Gracefully fail on ExecutionNotFound by transitioning the workflow the the 'FAILING' state. Subsequently, propeller will abort workflow tasks and transition the phase to 'FAILED'.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
This facilitates graceful failures when experiencing an ExecutionNotFound error during workflow transitions. The error occurs when flyteadmin either doesn't have the provided workflow or the workflow is deleted. Either case is an invalid state and should result in the failure of the specified workflow.
We handle the race condition where flyteadmin, during the two phase execution, is between initializing the CRD and writing to the DB by checking if the workflow is in the 'READY' phase.
By transitioning the workflow to the 'FAILING' phase propeller will attempt to abort all active tasks on subsequent processing before transitioning to the 'FAILED' phase and concluding processing. This approach is similar to the failing status transition when a flyte workflow is too large to update in the wfStore. 

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1048

## Follow-up issue
_NA_
