### PR TITLE
Order UpstreamNodeIds to ensure consistent compiler output

### DIFF
--- a/pkg/compiler/validators/node.go
+++ b/pkg/compiler/validators/node.go
@@ -3,6 +3,7 @@ package validators
 
 import (
 	"fmt"
+	"sort"
 
 	flyte "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	c "github.com/flyteorg/flytepropeller/pkg/compiler/common"
@@ -119,6 +120,13 @@ func ValidateNode(w c.WorkflowBuilder, n c.NodeBuilder, validateConditionTypes b
 		// Validate node output aliases
 		validateEffectiveOutputParameters(n, errs.NewScope())
 	}
+
+	if n.GetCoreNode().UpstreamNodeIds == nil {
+		n.GetCoreNode().UpstreamNodeIds = make([]string, 0, 0)
+	}
+
+	// Order upstream node ids to ensure consistent output of the compiler even if client ordering changes.
+	sort.Strings(n.GetCoreNode().UpstreamNodeIds)
 
 	// Validate branch node conditions and inner nodes.
 	if n.GetBranchNode() != nil {

--- a/pkg/compiler/validators/node.go
+++ b/pkg/compiler/validators/node.go
@@ -122,7 +122,7 @@ func ValidateNode(w c.WorkflowBuilder, n c.NodeBuilder, validateConditionTypes b
 	}
 
 	if n.GetCoreNode().UpstreamNodeIds == nil {
-		n.GetCoreNode().UpstreamNodeIds = make([]string, 0, 0)
+		n.GetCoreNode().UpstreamNodeIds = make([]string, 0)
 	}
 
 	// Order upstream node ids to ensure consistent output of the compiler even if client ordering changes.


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
When serializing workflows from flytekit (and other SDKs) there is no guarantee that node.UpstreamNodeIds will be ordered (in any consistent format). The ordering doesn't matter from the spec perspective since it doesn't dictate execution ordering. However, because it's an array/slice/list, when comparing the digest of the workflow being registered to those already registered, consistency in ordering matter. 

This PR alphabetically sorts the upstream_node_ids field of the node to ensure consistent ordering.

There is a caveat to the change from backward compatibility standpoint. If a user registers v1 of a workflow with descending (or random) ordering of upstream node ids, and then attempts to register the same spec again after applying this change, the registration will fail due to "Workflow exists with a different structure" error.
The right fix to address this is to recompute the digest of all registered workflows after we apply this change but given that this scenario isn't prevalent, I don't think it's necessary to do so.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue

https://github.com/flyteorg/flyte/issues/1460