### PR TITLE
Add support for defining status as a subresource of flyteworkflow CRD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/go-test/deep v1.0.7
 	github.com/golang/protobuf v1.4.3
+	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/magiconair/properties v1.8.4

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -315,7 +315,7 @@ func getAdminClient(ctx context.Context) (client service.AdminServiceClient, err
 	return clients.AdminClient(), nil
 }
 
-// Check to see if the status field is defined as a subresouce of the flyteworkflow CRD. This is
+// Check to see if the status field is defined as a subresource of the flyteworkflow CRD. This is
 // necessary to determine the correct API to use when updating flyteworkflow status'.
 func hasStatusSubresourceAPI(kubeclientset kubernetes.Interface) (bool, error) {
 	resourceList, err := kubeclientset.Discovery().ServerResourcesForGroupVersion(fmt.Sprintf("%s", v1alpha1.SchemeGroupVersion))
@@ -453,7 +453,7 @@ func New(ctx context.Context, cfg *config.Config, kubeclientset kubernetes.Inter
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to discover flyteworkflow resource API")
 	}
-	logger.Infof(ctx, "flyteworkflow status subresouce detected: %v", hasStatusSubresourceAPI)
+	logger.Infof(ctx, "flyteworkflow status subresource detected: %v", hasStatusSubresourceAPI)
 
 	handler := NewPropellerHandler(ctx, cfg, controller.workflowStore, workflowExecutor, scope, hasStatusSubresourceAPI)
 	controller.workerPool = NewWorkerPool(ctx, scope, workQ, handler)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -318,7 +318,7 @@ func getAdminClient(ctx context.Context) (client service.AdminServiceClient, err
 // Check to see if the status field is defined as a subresource of the flyteworkflow CRD. This is
 // necessary to determine the correct API to use when updating flyteworkflow status'.
 func hasStatusSubresourceAPI(kubeclientset kubernetes.Interface) (bool, error) {
-	resourceList, err := kubeclientset.Discovery().ServerResourcesForGroupVersion(fmt.Sprintf("%s", v1alpha1.SchemeGroupVersion))
+	resourceList, err := kubeclientset.Discovery().ServerResourcesForGroupVersion(v1alpha1.SchemeGroupVersion.String())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -261,7 +261,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 						Code:    "WorkflowTooLarge",
 						Message: "Workflow execution state is too large for Flyte to handle.",
 					})
-					if _, e := p.wfStore.UpdateStatus(ctx, mutableW, workflowstore.PriorityClassCritical); e != nil {
+					if _, e := p.wfStore.Update(ctx, mutableW, workflowstore.PriorityClassCritical); e != nil {
 						logger.Errorf(ctx, "Failed recording a large workflow as failed, reason: %s. Retrying...", e)
 						return e
 					}

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -48,7 +48,7 @@ func TestPropeller_Handle(t *testing.T) {
 		MaxWorkflowRetries: 0,
 	}
 
-	p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+	p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 
 	const namespace = "test"
 	const name = "123"
@@ -60,7 +60,7 @@ func TestPropeller_Handle(t *testing.T) {
 		scope := promutils.NewTestScope()
 		s := &mocks.FlyteWorkflow{}
 		exec := &mockExecutor{}
-		p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+		p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 		s.OnGetMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.Wrap(workflowstore.ErrStaleWorkflowError, "stale")).Once()
 		assert.NoError(t, p.Handle(ctx, namespace, name))
 	})
@@ -475,7 +475,7 @@ func TestPropeller_Handle_TurboMode(t *testing.T) {
 	const namespace = "test"
 	const name = "123"
 
-	p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+	p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 
 	t.Run("error", func(t *testing.T) {
 		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
@@ -677,7 +677,7 @@ func TestPropellerHandler_Initialize(t *testing.T) {
 		MaxWorkflowRetries: 0,
 	}
 
-	p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+	p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 
 	assert.NoError(t, p.Initialize(ctx))
 }
@@ -695,7 +695,7 @@ func TestNewPropellerHandler_UpdateFailure(t *testing.T) {
 		scope := promutils.NewTestScope()
 		s := &mocks.FlyteWorkflow{}
 		exec := &mockExecutor{}
-		p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+		p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 		wf := &v1alpha1.FlyteWorkflow{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name,
@@ -716,7 +716,7 @@ func TestNewPropellerHandler_UpdateFailure(t *testing.T) {
 		scope := promutils.NewTestScope()
 		s := &mocks.FlyteWorkflow{}
 		exec := &mockExecutor{}
-		p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+		p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 		wf := &v1alpha1.FlyteWorkflow{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name,
@@ -737,7 +737,7 @@ func TestNewPropellerHandler_UpdateFailure(t *testing.T) {
 		scope := promutils.NewTestScope()
 		s := &mocks.FlyteWorkflow{}
 		exec := &mockExecutor{}
-		p := NewPropellerHandler(ctx, cfg, s, exec, scope)
+		p := NewPropellerHandler(ctx, cfg, s, exec, scope, false)
 		wf := &v1alpha1.FlyteWorkflow{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name,

--- a/pkg/controller/workflowstore/passthrough.go
+++ b/pkg/controller/workflowstore/passthrough.go
@@ -25,9 +25,9 @@ type workflowstoreMetrics struct {
 }
 
 type passthroughWorkflowStore struct {
-	wfLister                listers.FlyteWorkflowLister
-	wfClientSet             v1alpha12.FlyteworkflowV1alpha1Interface
-	metrics                 *workflowstoreMetrics
+	wfLister    listers.FlyteWorkflowLister
+	wfClientSet v1alpha12.FlyteworkflowV1alpha1Interface
+	metrics     *workflowstoreMetrics
 }
 
 func (p *passthroughWorkflowStore) Get(ctx context.Context, namespace, name string) (*v1alpha1.FlyteWorkflow, error) {
@@ -114,8 +114,8 @@ func NewPassthroughWorkflowStore(_ context.Context, scope promutils.Scope, wfCli
 	}
 
 	return &passthroughWorkflowStore{
-		wfLister:                flyteworkflowLister,
-		wfClientSet:             wfClient,
-		metrics:                 metrics,
+		wfLister:    flyteworkflowLister,
+		wfClientSet: wfClient,
+		metrics:     metrics,
 	}
 }

--- a/pkg/controller/workflowstore/passthrough.go
+++ b/pkg/controller/workflowstore/passthrough.go
@@ -25,9 +25,9 @@ type workflowstoreMetrics struct {
 }
 
 type passthroughWorkflowStore struct {
-	wfLister    listers.FlyteWorkflowLister
-	wfClientSet v1alpha12.FlyteworkflowV1alpha1Interface
-	metrics     *workflowstoreMetrics
+	wfLister                listers.FlyteWorkflowLister
+	wfClientSet             v1alpha12.FlyteworkflowV1alpha1Interface
+	metrics                 *workflowstoreMetrics
 }
 
 func (p *passthroughWorkflowStore) Get(ctx context.Context, namespace, name string) (*v1alpha1.FlyteWorkflow, error) {
@@ -50,7 +50,7 @@ func (p *passthroughWorkflowStore) UpdateStatus(ctx context.Context, workflow *v
 	// Something has changed. Lets save
 	logger.Debugf(ctx, "Observed FlyteWorkflow State change. [%v] -> [%v]", workflow.Status.Phase.String(), workflow.Status.Phase.String())
 	t := p.metrics.workflowUpdateLatency.Start()
-	newWF, err = p.wfClientSet.FlyteWorkflows(workflow.Namespace).Update(ctx, workflow, v1.UpdateOptions{})
+	newWF, err = p.wfClientSet.FlyteWorkflows(workflow.Namespace).UpdateStatus(ctx, workflow, v1.UpdateOptions{})
 	if err != nil {
 		if kubeerrors.IsNotFound(err) {
 			return nil, nil
@@ -114,8 +114,8 @@ func NewPassthroughWorkflowStore(_ context.Context, scope promutils.Scope, wfCli
 	}
 
 	return &passthroughWorkflowStore{
-		wfLister:    flyteworkflowLister,
-		wfClientSet: wfClient,
-		metrics:     metrics,
+		wfLister:                flyteworkflowLister,
+		wfClientSet:             wfClient,
+		metrics:                 metrics,
 	}
 }


### PR DESCRIPTION
# TL;DR
Adding support for setting status as a subresource on the flyteworkflow CRD. This should reduce traffic to the kubernetes API server by reducing update message sizes.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Setting status as a subresource on the flyteworkflow CRD introduces a separate kubernetes rest API which partitions updates of the CRD spec and status subfields. This functionality seems straight-forward, but introduces complexities when trying to provide backward compatible support for existing deployments where the CRD doesn't have the status defined as a subresource. Specifically, the cases are described below for both the existing and non-existing CRD status subresource and the effect of the Update and UpdateStatus API calls.

case 1: subresource exists on CRD
    1.1 client.Update(...) -> succeeds, but status does not change - update doesn't care about changing status subresource
    1.2 client.UpdateStatus(...) -> succeeeds
case 2: no subresouce on CRD
    2.1 -> client.Update(...) -> succeeds (status does change)
    2.2 -> client.UpdateStatus(...) -> throws k8s error NotFound  - impossible to distinguish from 1.2 where the resource does not actually exist

Therefore, we determine if the status subresource API is available and use it to inform the correct commands to update flyteworkflow CRD status and spec subfields. This means the implementation works for the existing flyteworkflow CRD definition (ie. without status subresource) and offers advantages once the subresource is added.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/126

## Follow-up issue
_NA_
