### PR TITLE
[wip] Fix invalid Kubernetes pod names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.21.0
-	github.com/flyteorg/flyteplugins v0.6.1
+	github.com/flyteorg/flyteplugins v0.6.2-0.20210917221510-71f4801ce0c7
 	github.com/flyteorg/flytestdlib v0.3.34
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.21.0
-	github.com/flyteorg/flyteplugins v0.6.1
+	github.com/flyteorg/flyteplugins v0.6.2-0.20210916081054-fbb762f96a47
 	github.com/flyteorg/flytestdlib v0.3.34
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.21.0
-	github.com/flyteorg/flyteplugins v0.6.2-0.20210916081054-fbb762f96a47
+	github.com/flyteorg/flyteplugins v0.6.1
 	github.com/flyteorg/flytestdlib v0.3.34
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ github.com/flyteorg/flyteidl v0.21.0 h1:AwHNusfxJMfRRSDk2QWfb3aIlyLJrFWVGtpXCbCt
 github.com/flyteorg/flyteidl v0.21.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.6.1 h1:Mq9uM/IN6fXHo03NlXSa+to2GHEom2NAcRWlr+bVH6g=
 github.com/flyteorg/flyteplugins v0.6.1/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
-github.com/flyteorg/flyteplugins v0.6.2-0.20210916081054-fbb762f96a47 h1:zs3YFExyXWC0iWpiODqwwCU4S7cMTXjSR9KaoR/f2E4=
-github.com/flyteorg/flyteplugins v0.6.2-0.20210916081054-fbb762f96a47/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
 github.com/flyteorg/flytestdlib v0.3.34 h1:OOuV03X8c1AWInzBU6IRsqpEF6y8WDJngbPcdL4VktY=

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/flyteorg/flyteidl v0.21.0 h1:AwHNusfxJMfRRSDk2QWfb3aIlyLJrFWVGtpXCbCt
 github.com/flyteorg/flyteidl v0.21.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.6.1 h1:Mq9uM/IN6fXHo03NlXSa+to2GHEom2NAcRWlr+bVH6g=
 github.com/flyteorg/flyteplugins v0.6.1/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
+github.com/flyteorg/flyteplugins v0.6.2-0.20210916081054-fbb762f96a47 h1:zs3YFExyXWC0iWpiODqwwCU4S7cMTXjSR9KaoR/f2E4=
+github.com/flyteorg/flyteplugins v0.6.2-0.20210916081054-fbb762f96a47/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
 github.com/flyteorg/flytestdlib v0.3.34 h1:OOuV03X8c1AWInzBU6IRsqpEF6y8WDJngbPcdL4VktY=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flyteorg/flyteidl v0.21.0 h1:AwHNusfxJMfRRSDk2QWfb3aIlyLJrFWVGtpXCbCtJ5A=
 github.com/flyteorg/flyteidl v0.21.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
-github.com/flyteorg/flyteplugins v0.6.1 h1:Mq9uM/IN6fXHo03NlXSa+to2GHEom2NAcRWlr+bVH6g=
-github.com/flyteorg/flyteplugins v0.6.1/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
+github.com/flyteorg/flyteplugins v0.6.2-0.20210917221510-71f4801ce0c7 h1:JRBZeHGjVZyZLruchf2HczDLKFifW7FrY7KAt0eCw6o=
+github.com/flyteorg/flyteplugins v0.6.2-0.20210917221510-71f4801ce0c7/go.mod h1:rPzV/KS6h0BkgK0Z+CnO6JjY58tzUdYvDLMYS10IKG0=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
 github.com/flyteorg/flytestdlib v0.3.34 h1:OOuV03X8c1AWInzBU6IRsqpEF6y8WDJngbPcdL4VktY=

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"reflect"
 	"strings"
 	"time"
@@ -105,6 +106,15 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
+	pod, casted := o.(*v1.Pod)
+	if casted {
+		println("Is a pod, name" + pod.Name)
+		if errs := validation.IsDNS1123Label(pod.Name); len(errs) > 0 {
+			pod.Name = strings.ToLower(pod.Name)
+		}
+	} else {
+		println("Not a pod")
+	}
 	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 
 	if !e.plugin.GetProperties().DisableInjectOwnerReferences {

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -3,10 +3,11 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"reflect"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -106,6 +106,7 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
+	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 	pod, casted := o.(*v1.Pod)
 	if casted {
 		println("Is a pod, name" + pod.Name)
@@ -115,7 +116,6 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	} else {
 		println("Not a pod")
 	}
-	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 
 	if !e.plugin.GetProperties().DisableInjectOwnerReferences {
 		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"reflect"
 	"strings"
 	"time"
@@ -105,16 +106,7 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
-	//o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
-	//pod, casted := o.(*v1.Pod)
-	//if casted {
-	//	println("Is a pod, name" + pod.Name)
-	//	if errs := validation.IsDNS1123Label(pod.Name); len(errs) > 0 {
-	//		pod.Name = strings.ToLower(pod.Name)
-	//	}
-	//} else {
-	//	println("Not a pod")
-	//}
+	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 
 	if !e.plugin.GetProperties().DisableInjectOwnerReferences {
 		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})
@@ -123,6 +115,13 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	if cfg.InjectFinalizer && !e.plugin.GetProperties().DisableInjectFinalizer {
 		f := append(o.GetFinalizers(), finalizer)
 		o.SetFinalizers(f)
+	}
+
+	pod, casted := o.(*v1.Pod)
+	if casted {
+		if errs := validation.IsDNS1123Label(pod.Name); len(errs) > 0 {
+			pod.Name = utils.ConvertToDNS1123CompatibleString(pod.Name)
+		}
 	}
 }
 

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -105,7 +105,7 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
-	o.SetName(strings.ToLower(taskCtx.GetTaskExecutionID().GetGeneratedName()))
+	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 
 	if !e.plugin.GetProperties().DisableInjectOwnerReferences {
 		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"reflect"
 	"strings"
 	"time"
@@ -106,16 +105,16 @@ func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetad
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
-	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
-	pod, casted := o.(*v1.Pod)
-	if casted {
-		println("Is a pod, name" + pod.Name)
-		if errs := validation.IsDNS1123Label(pod.Name); len(errs) > 0 {
-			pod.Name = strings.ToLower(pod.Name)
-		}
-	} else {
-		println("Not a pod")
-	}
+	//o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
+	//pod, casted := o.(*v1.Pod)
+	//if casted {
+	//	println("Is a pod, name" + pod.Name)
+	//	if errs := validation.IsDNS1123Label(pod.Name); len(errs) > 0 {
+	//		pod.Name = strings.ToLower(pod.Name)
+	//	}
+	//} else {
+	//	println("Not a pod")
+	//}
 
 	if !e.plugin.GetProperties().DisableInjectOwnerReferences {
 		o.SetOwnerReferences([]metav1.OwnerReference{taskCtx.GetOwnerReference()})

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -258,6 +258,13 @@ func (e *PluginManager) CheckResourcePhase(ctx context.Context, tCtx pluginsCore
 	e.AddObjectMetadata(tCtx.TaskExecutionMetadata(), o, config.GetK8sPluginConfig())
 	nsName := k8stypes.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}
 	// Attempt to get resource from informer cache, if not found, retrieve it from API server.
+	pod, casted := o.(*v1.Pod)
+	if casted {
+		if errs := validation.IsDNS1123Label(pod.Name); len(errs) > 0 {
+			pod.Name = rand.String(4)
+		}
+	}
+
 	if err := e.kubeClient.GetClient().Get(ctx, nsName, o); err != nil {
 		if IsK8sObjectNotExists(err) {
 			// This happens sometimes because a node gets removed and K8s deletes the pod. This will result in a


### PR DESCRIPTION
# TODO
Update go.mod

# TL;DR
When running task execution, the propeller attempt to use the unvetted generated name for the execution as the pod name which creates errors on pod creation (e.g. `uw51wxgz3g-orgflyteexamplesHelloWorldTask-0`). The capitalized letters violates the Kubernetes' pod name restriction which is based on [the DNS label standard as defined in RFC-1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/). This PR attempts to address this problem (and future problems) by adding validation and conversion after the metadata (including the name) get added to the pod request object.
https://github.com/flyteorg/flytepropeller/blob/a1d959bbe20026145d27597f34501e59c9d6dbfd/pkg/controller/nodes/task/k8s/plugin_manager.go#L108 this overrides any changes made on the plugin side.

# Before:
`[Invalid] failed to create resource, caused by: Pod \"uw51wxgz3g-orgflyteexamplesHelloWorldTask-0\" is invalid: metadata.name: Invalid value: \"uw51wxgz3g-orgflyteexamplesHelloWorldTask-0\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character`

# After:
`{"json":{"exec_id":"yftcgyyovn","node":"orgflyteexamplesGreetTask","ns":"flytetester-development","res_ver":"271340","routine":"worker-1","src":"plugin_manager.go:211","tasktype":"java-task","wf":"flytetester:development:.flytegen.org.flyte.examples.GreetTask"},"level":"info","msg":"Creating Object: Type:[/v1, Kind=pod], Object:[flytetester-development/yftcgyyovn-orgflyteexamples-greet-task-0]","ts":"2021-09-17T22:29:26Z"}
{"json":{"exec_id":"yftcgyyovn","node":"orgflyteexamplesGreetTask","ns":"flytetester-development","res_ver":"271340","routine":"worker-1","src":"plugin_manager.go:185","tasktype":"java-task","wf":"flytetester:development:.flytegen.org.flyte.examples.GreetTask"},"level":"info","msg":"The resource requirement for creating Pod [flytetester-development/yftcgyyovn-orgflyteexamples-greet-task-0] is [[{[cpu]: [100m]} {[memory]: [200Mi]}]]\n","ts":"2021-09-17T22:29:26Z"}`

Also see https://github.com/flyteorg/flyteplugins/pull/211


## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/flyteorg/flyte/issues/1172

## Follow-up issue

