### PR TITLE
Add TLSConfig to RedisConfig and NewRedisClient #patch

### DIFF
--- a/pkg/controller/nodes/task/resourcemanager/config/config.go
+++ b/pkg/controller/nodes/task/resourcemanager/config/config.go
@@ -77,7 +77,6 @@ func ParseTLSConfig(cfg TLSConfig) *tls.Config {
 	// Parses TLSConfig settings into a proper tls.Config object. Returns a pointer
 	// to nil if no settings were manually defined (i.e. cfg is empty) to keep tls disabled.
 	if cfg != (TLSConfig{}) {
-
 		return &tls.Config{
 			//Certificates []Certificate,
 			//RootCAs *x509.CertPool,
@@ -86,9 +85,8 @@ func ParseTLSConfig(cfg TLSConfig) *tls.Config {
 			MinVersion: GetTLSVersion(cfg.MinVersion),
 			MaxVersion: GetTLSVersion(cfg.MaxVersion),
 		}
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // Retrieves the current config value or default.

--- a/pkg/controller/nodes/task/resourcemanager/config/config.go
+++ b/pkg/controller/nodes/task/resourcemanager/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"github.com/flyteorg/flytepropeller/pkg/controller/config"
-	"crypto/tls"
 )
 
 //go:generate pflags Config --default-var=defaultConfig
@@ -39,10 +38,24 @@ type RedisConfig struct {
 	HostPaths   []string `json:"hostPaths" pflag:",Redis hosts locations."`
 	PrimaryName string   `json:"primaryName" pflag:",Redis primary name, fill in only if you are connecting to a redis sentinel cluster."`
 	// deprecated: Please use HostPaths instead
-	HostPath   string `json:"hostPath" pflag:",Redis host location"`
-	HostKey    string `json:"hostKey" pflag:",Key for local Redis access"`
-	MaxRetries int    `json:"maxRetries" pflag:",See Redis client options for more info"`
-	TLSConfig  *tls.Config `json:"TLSConfig" pflag:",See the crytpo/tls config object for more info"`
+	HostPath   string    `json:"hostPath" pflag:",Redis host location"`
+	HostKey    string    `json:"hostKey" pflag:",Key for local Redis access"`
+	MaxRetries int       `json:"maxRetries" pflag:",See Redis client options for more info"`
+	TLSConfig  TLSConfig `json:"tlsConfig" pflag:",See the crytpo/tls config object for more info"`
+}
+
+// Specific configs for Redis TLS
+// Ref: https://pkg.go.dev/crypto/tls#Config for informations on how to fill in these fields.
+type TLSConfig struct {
+	NextProtos                  []string `json:"nextProtos" pflag:",List of supported application level protocols, in order of preference."`
+	ServerName                  string   `json:"serverName" pflag:",Used to verify the hostname on the returned certificates unless InsecureSkipVerify is given."`
+	InsecureSkipVerify          bool     `json:"insecureSkipVerify" pflag:",Whether a client verifies the server's certificate chain and host name"`
+	SessionTicketsDisabled      bool     `json:"sessionTicketsDisabled" pflag:",May be set to true to disable session ticket and PSK (resumption) support"`
+	MinVersion                  uint16   `json:"minVersion" pflag:",Minimum TLS version that is acceptable"`
+	MaxVersion                  uint16   `json:"maxVersion" pflag:",Maximum TLS version that is acceptable."`
+	CurvePreferences            uint16   `json:"curvePreferences" pflag:",CurvePreferences contains the elliptic curves that will be used in an ECDHE handshake, in preference order. If empty, the default will be used. See https://pkg.go.dev/crypto/tls#CurveID."`
+	DynamicRecordSizingDisabled bool     `json:"dynamicRecordSizingDisabled" pflag:",Disables adaptive sizing of TLS records.When true, the largest possible TLS record size is always used."`
+	Renegotiation               int      `json:"renegotiation" pflag:",What type of renegotiations are supported. The default, none, is correct for most applications."`
 }
 
 // Retrieves the current config value or default.

--- a/pkg/controller/nodes/task/resourcemanager/config/config.go
+++ b/pkg/controller/nodes/task/resourcemanager/config/config.go
@@ -77,6 +77,7 @@ func ParseTLSConfig(cfg TLSConfig) *tls.Config {
 	// Parses TLSConfig settings into a proper tls.Config object. Returns a pointer
 	// to nil if no settings were manually defined (i.e. cfg is empty) to keep tls disabled.
 	if cfg != (TLSConfig{}) {
+		/* #nosec G402 */
 		return &tls.Config{
 			//Certificates []Certificate,
 			//RootCAs *x509.CertPool,

--- a/pkg/controller/nodes/task/resourcemanager/config/config.go
+++ b/pkg/controller/nodes/task/resourcemanager/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/flyteorg/flytepropeller/pkg/controller/config"
+	"crypto/tls"
 )
 
 //go:generate pflags Config --default-var=defaultConfig
@@ -41,6 +42,7 @@ type RedisConfig struct {
 	HostPath   string `json:"hostPath" pflag:",Redis host location"`
 	HostKey    string `json:"hostKey" pflag:",Key for local Redis access"`
 	MaxRetries int    `json:"maxRetries" pflag:",See Redis client options for more info"`
+	TLSConfig  *tls.Config `json:"TLSConfig" pflag:",See the crytpo/tls config object for more info"`
 }
 
 // Retrieves the current config value or default.

--- a/pkg/controller/nodes/task/resourcemanager/config/config_flags.go
+++ b/pkg/controller/nodes/task/resourcemanager/config/config_flags.go
@@ -57,5 +57,8 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redis.hostPath"), defaultConfig.RedisConfig.HostPath, "Redis host location")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redis.hostKey"), defaultConfig.RedisConfig.HostKey, "Key for local Redis access")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "redis.maxRetries"), defaultConfig.RedisConfig.MaxRetries, "See Redis client options for more info")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redis.tlsConfig.serverName"), defaultConfig.RedisConfig.TLSConfig.ServerName, "Used to verify the hostname.")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redis.tlsConfig.minVersion"), defaultConfig.RedisConfig.TLSConfig.MinVersion, "Minimum TLS version that is acceptable")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "redis.tlsConfig.maxVersion"), defaultConfig.RedisConfig.TLSConfig.MaxVersion, "Maximum TLS version that is acceptable.")
 	return cmdFlags
 }

--- a/pkg/controller/nodes/task/resourcemanager/config/config_flags_test.go
+++ b/pkg/controller/nodes/task/resourcemanager/config/config_flags_test.go
@@ -197,4 +197,46 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_redis.tlsConfig.serverName", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("redis.tlsConfig.serverName", testValue)
+			if vString, err := cmdFlags.GetString("redis.tlsConfig.serverName"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.RedisConfig.TLSConfig.ServerName)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_redis.tlsConfig.minVersion", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("redis.tlsConfig.minVersion", testValue)
+			if vString, err := cmdFlags.GetString("redis.tlsConfig.minVersion"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.RedisConfig.TLSConfig.MinVersion)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_redis.tlsConfig.maxVersion", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("redis.tlsConfig.maxVersion", testValue)
+			if vString, err := cmdFlags.GetString("redis.tlsConfig.maxVersion"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.RedisConfig.TLSConfig.MaxVersion)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/pkg/controller/nodes/task/resourcemanager/redis_client.go
+++ b/pkg/controller/nodes/task/resourcemanager/redis_client.go
@@ -67,6 +67,7 @@ func NewRedisClient(ctx context.Context, config config.RedisConfig) (RedisClient
 			Password:   config.HostKey,
 			DB:         0, // use default DB
 			MaxRetries: config.MaxRetries,
+			TLSConfig:  config.TLSConfig,
 		}),
 	}
 

--- a/pkg/controller/nodes/task/resourcemanager/redis_client.go
+++ b/pkg/controller/nodes/task/resourcemanager/redis_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
-	rscConfig "github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
 
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/go-redis/redis"
@@ -55,29 +54,29 @@ func (r *Redis) Ping() (string, error) {
 	return r.c.Ping().Result()
 }
 
-func NewRedisClient(ctx context.Context, config config.RedisConfig) (RedisClient, error) {
+func NewRedisClient(ctx context.Context, cfg config.RedisConfig) (RedisClient, error) {
 	// Backward compatibility
-	if len(config.HostPaths) == 0 && len(config.HostPath) > 0 {
-		config.HostPaths = []string{config.HostPath}
+	if len(cfg.HostPaths) == 0 && len(cfg.HostPath) > 0 {
+		cfg.HostPaths = []string{cfg.HostPath}
 	}
 
 	client := &Redis{
 		c: redis.NewUniversalClient(&redis.UniversalOptions{
-			Addrs:      config.HostPaths,
-			MasterName: config.PrimaryName,
-			Password:   config.HostKey,
+			Addrs:      cfg.HostPaths,
+			MasterName: cfg.PrimaryName,
+			Password:   cfg.HostKey,
 			DB:         0, // use default DB
-			MaxRetries: config.MaxRetries,
-			TLSConfig:  rscConfig.ParseTLSConfig(config.TLSConfig),
+			MaxRetries: cfg.MaxRetries,
+			TLSConfig:  config.ParseTLSConfig(cfg.TLSConfig),
 		}),
 	}
 
 	_, err := client.Ping()
 	if err != nil {
-		logger.Errorf(ctx, "Error creating Redis client at [%+v]. Error: %v", config.HostPaths, err)
+		logger.Errorf(ctx, "Error creating Redis client at [%+v]. Error: %v", cfg.HostPaths, err)
 		return nil, err
 	}
 
-	logger.Infof(ctx, "Created Redis client with host [%+v]...", config.HostPaths)
+	logger.Infof(ctx, "Created Redis client with host [%+v]...", cfg.HostPaths)
 	return client, nil
 }

--- a/pkg/controller/nodes/task/resourcemanager/redis_client.go
+++ b/pkg/controller/nodes/task/resourcemanager/redis_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
+	rscConfig "github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
 
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/go-redis/redis"
@@ -67,7 +68,7 @@ func NewRedisClient(ctx context.Context, config config.RedisConfig) (RedisClient
 			Password:   config.HostKey,
 			DB:         0, // use default DB
 			MaxRetries: config.MaxRetries,
-			TLSConfig:  config.TLSConfig,
+			TLSConfig:  rscConfig.ParseTLSConfig(config.TLSConfig),
 		}),
 	}
 

--- a/pkg/controller/nodes/task/resourcemanager/redis_resourcemanager_test.go
+++ b/pkg/controller/nodes/task/resourcemanager/redis_resourcemanager_test.go
@@ -2,11 +2,14 @@ package resourcemanager
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/resourcemanager/config"
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/resourcemanager/mocks"
+
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -133,4 +136,14 @@ func TestRedisResourceManager_checkAgainstConstraints(t *testing.T) {
 		assert.False(t, ok)
 		assert.Equal(t, 0, idx)
 	})
+}
+
+func TestRedisTLSConfig(t *testing.T) {
+	var st config.TLSConfig
+	cfg := config.GetConfig()
+	fmt.Println(cfg)
+
+	if st == cfg.RedisConfig.TLSConfig {
+		fmt.Println("Nothing set")
+	}
 }


### PR DESCRIPTION
# TL;DR
Adds the TLSConfig field to respective structs to allow for secure Redis communication. 
Work in progress.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Based on the entirety of possible [redis options](https://github.com/go-redis/redis/blob/ce40cd942a72c4a93f9025047e6fd3f510700ab3/universal.go), I added the TLSConfig field to the instantiation in NewRedisClient and also extended flytes own RedisConfig with that field. 

## Tracking Issue
No issue yet, do you want me to open one?

## Follow-up issue
_NA_
