### PR TITLE
Do not run container as root #patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /artifacts /bin
 
 RUN apk --update add ca-certificates
 
-RUN groupadd -g 1000 flyte && useradd -r -u 1000 -g flyte flyte
+RUN addgroup -S flyte && adduser -S flyte -G flyte
 USER flyte
 
 CMD ["flytepropeller"]


### PR DESCRIPTION

# TL;DR
Fixes the Docker container not to run as root. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
The change is made in the Dockerfile, where we create a new group and user to use for running the command. 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1606

## Follow-up issue

