### PR TITLE
Clear managed fields on FlyteWorkflow CRD

### DIFF
--- a/pkg/controller/workflowstore/resource_version_caching.go
+++ b/pkg/controller/workflowstore/resource_version_caching.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 	"github.com/flyteorg/flytestdlib/promutils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TODO - optimization maybe? we can move this to predicate check, before we add it to the queue?
@@ -94,6 +96,14 @@ func (r *resourceVersionCaching) UpdateStatus(ctx context.Context, workflow *v1a
 
 func (r *resourceVersionCaching) Update(ctx context.Context, workflow *v1alpha1.FlyteWorkflow, priorityClass PriorityClass) (
 	newWF *v1alpha1.FlyteWorkflow, err error) {
+	// If the workflow has any managed fields setting the array to one empty ManagedField clears them in the CRD.
+	// FlyteWorkflow CRDs are only managed by a single FlytePropeller instance and therefore the managed fields paradigm
+	// does not add useful functionality. Clearing them reduces CRD size, improving etcd I/O performance.
+	if len(workflow.ObjectMeta.ManagedFields) > 0 {
+		workflow.ObjectMeta.ManagedFields = workflow.ObjectMeta.ManagedFields[:1]
+		workflow.ObjectMeta.ManagedFields[0] = metav1.ManagedFieldsEntry{}
+	}
+
 	newWF, err = r.w.Update(ctx, workflow, priorityClass)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# TL;DR
During each FlyteWorkflow CRD update we check for existing managed field entities and set the field to a list with a single empty instance. K8s server side apply uses this to clear managed fields. Managed fields are unused since Flyte ensures only a single FlytePropeller instance manages each FlyteWorkflow. Removing them reduces CRD size to improve etcd read / write performance.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1714

## Follow-up issue
_NA_