### PR TITLE
MaxParallelism now accounts for maximum nodes in progress with actual work - Task / LP

### DIFF
--- a/pkg/controller/nodes/subworkflow/handler_test.go
+++ b/pkg/controller/nodes/subworkflow/handler_test.go
@@ -108,6 +108,7 @@ func createNodeContextWithVersion(phase v1alpha1.WorkflowNodePhase, n v1alpha1.E
 	ex.OnGetParentInfo().Return(nil)
 	ex.OnGetName().Return("name")
 	ex.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+	ex.OnIncrementParallelism().Return(1)
 
 	nCtx.OnExecutionContext().Return(ex)
 
@@ -171,6 +172,8 @@ func TestWorkflowNodeHandler_StartNode_Launchplan(t *testing.T) {
 		s, err := h.Handle(ctx, nCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, handler.EPhaseRunning, s.Info().GetPhase())
+		c := nCtx.ExecutionContext().(*execMocks.ExecutionContext)
+		c.AssertCalled(t, "IncrementParallelism")
 	})
 
 	t.Run("happy v1", func(t *testing.T) {
@@ -194,6 +197,8 @@ func TestWorkflowNodeHandler_StartNode_Launchplan(t *testing.T) {
 		s, err := h.Handle(ctx, nCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, handler.EPhaseRunning, s.Info().GetPhase())
+		c := nCtx.ExecutionContext().(*execMocks.ExecutionContext)
+		c.AssertCalled(t, "IncrementParallelism")
 	})
 }
 
@@ -243,6 +248,8 @@ func TestWorkflowNodeHandler_CheckNodeStatus(t *testing.T) {
 		s, err := h.Handle(ctx, nCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, handler.EPhaseRunning, s.Info().GetPhase())
+		c := nCtx.ExecutionContext().(*execMocks.ExecutionContext)
+		c.AssertCalled(t, "IncrementParallelism")
 	})
 	t.Run("stillRunning V1", func(t *testing.T) {
 
@@ -262,6 +269,8 @@ func TestWorkflowNodeHandler_CheckNodeStatus(t *testing.T) {
 		s, err := h.Handle(ctx, nCtx)
 		assert.NoError(t, err)
 		assert.Equal(t, handler.EPhaseRunning, s.Info().GetPhase())
+		c := nCtx.ExecutionContext().(*execMocks.ExecutionContext)
+		c.AssertCalled(t, "IncrementParallelism")
 	})
 }
 

--- a/pkg/controller/nodes/subworkflow/launchplan.go
+++ b/pkg/controller/nodes/subworkflow/launchplan.go
@@ -95,7 +95,8 @@ func (l *launchPlanHandler) StartLaunchPlan(ctx context.Context, nCtx handler.No
 			return handler.UnknownTransition, err
 		}
 	} else {
-		logger.Infof(ctx, "Launched launchplan with ID [%s]", childID.Name)
+		eCtx := nCtx.ExecutionContext()
+		logger.Infof(ctx, "Launched launchplan with ID [%s], Parallelism is now set to [%d]", childID.Name, eCtx.IncrementParallelism())
 	}
 
 	return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(&handler.ExecutionInfo{
@@ -134,7 +135,8 @@ func (l *launchPlanHandler) CheckLaunchPlanStatus(ctx context.Context, nCtx hand
 
 	if wfStatusClosure == nil {
 		logger.Info(ctx, "Retrieved Launch Plan status is nil. This might indicate pressure on the admin cache."+
-			" Consider tweaking its size to allow for more concurrent executions to be cached.")
+			" Consider tweaking its size to allow for more concurrent executions to be cached."+
+			" Assuming LP is running, parallelism [%d].", nCtx.ExecutionContext().IncrementParallelism())
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(&handler.ExecutionInfo{
 			WorkflowNodeInfo: &handler.WorkflowNodeInfo{LaunchedWorkflowID: childID},
 		})), nil
@@ -184,6 +186,7 @@ func (l *launchPlanHandler) CheckLaunchPlanStatus(ctx context.Context, nCtx hand
 			OutputInfo:       oInfo,
 		})), nil
 	}
+	logger.Infof(ctx, "LaunchPlan running, parallelism is now set to [%d]", nCtx.ExecutionContext().IncrementParallelism())
 	return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(nil)), nil
 }
 

--- a/pkg/controller/nodes/subworkflow/launchplan_test.go
+++ b/pkg/controller/nodes/subworkflow/launchplan_test.go
@@ -255,6 +255,7 @@ func TestSubWorkflowHandler_StartLaunchPlan(t *testing.T) {
 				WorkflowExecutionIdentifier: recoveredExecID,
 			},
 		})
+		ectx.OnIncrementParallelism().Return(1)
 		nCtx.OnExecutionContext().Return(ectx)
 		nCtx.OnCurrentAttempt().Return(uint32(1))
 		nCtx.OnNode().Return(mockNode)


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Before this PR, Flytepropeller greedily executed all nodes, but only blocked task nodes in running state to match the max parallelism limits. The idea of max parallelism is to limit the maximum amount of work that can be done by propeller. Thus this change limits even launch plan nodes and prevents nodes from being queued. This improves the performance of propeller drastically. This coupled with event filter, can allow parallelism to be increased without severely degrading the performance.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1716

## Follow-up issue
_NA_

