### PR TITLE
Make default backoff MaxDuration 20sec

### DIFF
--- a/pkg/controller/nodes/task/config/config.go
+++ b/pkg/controller/nodes/task/config/config.go
@@ -27,7 +27,7 @@ var (
 		},
 		BackOffConfig: BackOffConfig{
 			BaseSecond:  2,
-			MaxDuration: config.Duration{Duration: time.Minute * 10},
+			MaxDuration: config.Duration{Duration: time.Second * 20},
 		},
 		MaxErrorMessageLength: 2048,
 	}


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Update default backoff maxDuration to 20s (from 10mins).

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
The way the backoff controller works has a few issues:
1. The exponent (how big the backoff should be) is the same across all namespaces so if one namespace is experiencing resource limitation, and gets to the max backoff, if any other namespace starts to backoff, it'll also use the max backoff instead of starting with smaller increments.

2. The default maxBackoff (10mins) assumes user's work will take 10mins to clear some resources. By observing our users' use-cases it seems that much shorter workloads are very common now... so setting maxBackoff to 20s is more appropriate.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/1749
