### PR TITLE
Explicit group and user id #patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /artifacts /bin
 
 RUN apk --update add ca-certificates
 
-RUN addgroup -S flyte && adduser -S flyte -G flyte
+RUN addgroup -g 1001 -S flyte && adduser --uid 1001 -S flyte -G flyte
 USER flyte
 
 CMD ["flytepropeller"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=builder /artifacts /bin
 
 RUN apk --update add ca-certificates
 
-RUN addgroup -g 1001 -S flyte && adduser --uid 1001 -S flyte -G flyte
-USER flyte
+RUN addgroup -g 65534 -S 65534 && adduser --uid 1001 -S 1001 -G 65534
+USER 1001
 
 CMD ["flytepropeller"]


### PR DESCRIPTION
# TL;DR
We set the user and group id explicitly in the Dockerfile

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
We assign numerical id's in the adduser and addgroup commands

## Tracking Issue

https://github.com/flyteorg/flyte/issues/1606
