### PR TITLE
Bump flytestdlib to v0.4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ linux_compile:
 .PHONY: compile
 compile:
 	mkdir -p ./bin
-	go build -o bin/flytepropeller ./cmd/controller/main.go && cp bin/flytepropeller ${GOPATH}/bin
+	go build -o bin/flytepropeller ./cmd/controller/main.go
 	go build -o bin/kubectl-flyte ./cmd/kubectl-flyte/main.go && cp bin/kubectl-flyte ${GOPATH}/bin
 
 cross_compile:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ linux_compile:
 .PHONY: compile
 compile:
 	mkdir -p ./bin
-	go build -o bin/flytepropeller ./cmd/controller/main.go
+	go build -o bin/flytepropeller ./cmd/controller/main.go && cp bin/flytepropeller ${GOPATH}/bin
 	go build -o bin/kubectl-flyte ./cmd/kubectl-flyte/main.go && cp bin/kubectl-flyte ${GOPATH}/bin
 
 cross_compile:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/flyteorg/flyteidl v0.21.4
 	github.com/flyteorg/flyteplugins v0.7.2
-	github.com/flyteorg/flytestdlib v0.4.1
+	github.com/flyteorg/flytestdlib v0.4.4
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/go-test/deep v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/flyteorg/flyteplugins v0.7.2 h1:WLftq5+/RYt3HLc/mjRprqexot3brlMJHMH1y
 github.com/flyteorg/flyteplugins v0.7.2/go.mod h1:kOiuXk1ddIEVSPoHcc4kBfVQcLuyf8jw3vWJT2Was90=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.36/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
-github.com/flyteorg/flytestdlib v0.4.1 h1:tEi/B9Q2T2VUOUQiFGoynmSJ8xNjdBgcZ4tgsCzpHAk=
-github.com/flyteorg/flytestdlib v0.4.1/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
+github.com/flyteorg/flytestdlib v0.4.4 h1:oPADei4KEjxtUqkTwrIjXB1nuH+JEKjwmwF92DSO3NM=
+github.com/flyteorg/flytestdlib v0.4.4/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
update flytestdlib version to support docs generate command (`flytepropeller config docs`)
https://github.com/flyteorg/flytestdlib/releases/tag/v0.4.4

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

## Follow-up issue
_NA_
