### PR TITLE
Fix violated uniqueness constraint on task events

### DIFF
--- a/events/admin_eventsink.go
+++ b/events/admin_eventsink.go
@@ -111,7 +111,7 @@ func IDFromMessage(message proto.Message) ([]byte, error) {
 	case *event.NodeExecutionEvent:
 		nid := eventMessage.Id
 		wid := nid.ExecutionId
-		id = fmt.Sprintf("%s:%s:%s:%s:%d", wid.Project, wid.Domain, wid.Name, nid.NodeId, eventMessage.Phase)
+		id = fmt.Sprintf("%s:%s:%s:%s:%s:%d", wid.Project, wid.Domain, wid.Name, nid.NodeId, eventMessage.RetryGroup, eventMessage.Phase)
 	case *event.TaskExecutionEvent:
 		tid := eventMessage.TaskId
 		nid := eventMessage.ParentNodeExecutionId

--- a/events/admin_eventsink.go
+++ b/events/admin_eventsink.go
@@ -116,7 +116,7 @@ func IDFromMessage(message proto.Message) ([]byte, error) {
 		tid := eventMessage.TaskId
 		nid := eventMessage.ParentNodeExecutionId
 		wid := nid.ExecutionId
-		id = fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%d", wid.Project, wid.Domain, wid.Name, nid.NodeId, tid.Name, tid.Version, eventMessage.Phase, eventMessage.PhaseVersion)
+		id = fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%d:%d", wid.Project, wid.Domain, wid.Name, nid.NodeId, tid.Name, tid.Version, eventMessage.RetryAttempt, eventMessage.Phase, eventMessage.PhaseVersion)
 	default:
 		return nil, fmt.Errorf("unknown event type [%s]", eventMessage.String())
 	}

--- a/events/admin_eventsink_test.go
+++ b/events/admin_eventsink_test.go
@@ -190,6 +190,23 @@ func TestAdminFilterContains(t *testing.T) {
 }
 
 func TestIDFromMessage(t *testing.T) {
+	nodeEventRetryGroup := &event.NodeExecutionEvent{
+		Id: &core.NodeExecutionIdentifier{
+			NodeId: "node-id",
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "n",
+			},
+		},
+		Phase:        core.NodeExecution_FAILED,
+		OccurredAt:   ptypes.TimestampNow(),
+		ProducerId:   "",
+		InputUri:     "input-uri",
+		OutputResult: &event.NodeExecutionEvent_OutputUri{OutputUri: ""},
+		RetryGroup:   "1",
+	}
+
 	retry0 := &event.TaskExecutionEvent{
 		Phase:        core.TaskExecution_SUCCEEDED,
 		OccurredAt:   ptypes.TimestampNow(),
@@ -229,7 +246,8 @@ func TestIDFromMessage(t *testing.T) {
 		want    string
 	}{
 		{"workflow", wfEvent, "p:d:n:2"},
-		{"node", nodeEvent, "p:d:n:node-id:5"},
+		{"node", nodeEvent, "p:d:n:node-id::5"},
+		{"node", nodeEventRetryGroup, "p:d:n:node-id:1:5"},
 		{"task", taskEvent, "p:d:n:node-id:task-id::1:3:0"},
 		{"task", retry0, "p:d:n:node-id:task-id::0:3:0"},
 		{"task", pv1, "p:d:n:node-id:task-id::0:3:1"},

--- a/events/admin_eventsink_test.go
+++ b/events/admin_eventsink_test.go
@@ -190,6 +190,39 @@ func TestAdminFilterContains(t *testing.T) {
 }
 
 func TestIDFromMessage(t *testing.T) {
+	retry0 := &event.TaskExecutionEvent{
+		Phase:        core.TaskExecution_SUCCEEDED,
+		OccurredAt:   ptypes.TimestampNow(),
+		TaskId:       &core.Identifier{ResourceType: core.ResourceType_TASK, Name: "task-id"},
+		RetryAttempt: 0,
+		ParentNodeExecutionId: &core.NodeExecutionIdentifier{
+			NodeId: "node-id",
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "n",
+			},
+		},
+		Logs: []*core.TaskLog{{Uri: "logs.txt"}},
+	}
+
+	pv1 := &event.TaskExecutionEvent{
+		Phase:        core.TaskExecution_SUCCEEDED,
+		PhaseVersion: 1,
+		OccurredAt:   ptypes.TimestampNow(),
+		TaskId:       &core.Identifier{ResourceType: core.ResourceType_TASK, Name: "task-id"},
+		RetryAttempt: 0,
+		ParentNodeExecutionId: &core.NodeExecutionIdentifier{
+			NodeId: "node-id",
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: "p",
+				Domain:  "d",
+				Name:    "n",
+			},
+		},
+		Logs: []*core.TaskLog{{Uri: "logs.txt"}},
+	}
+
 	tests := []struct {
 		name    string
 		message proto.Message
@@ -197,7 +230,9 @@ func TestIDFromMessage(t *testing.T) {
 	}{
 		{"workflow", wfEvent, "p:d:n:2"},
 		{"node", nodeEvent, "p:d:n:node-id:5"},
-		{"task", taskEvent, "p:d:n:node-id:task-id::3:0"},
+		{"task", taskEvent, "p:d:n:node-id:task-id::1:3:0"},
+		{"task", retry0, "p:d:n:node-id:task-id::0:3:0"},
+		{"task", pv1, "p:d:n:node-id:task-id::0:3:1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
When the unique id is constructed for a task event, it should take into account the retry attempt

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1824

## Follow-up issue
_NA_
