### PR TITLE
Gracefully fail when NodeEvent exceeds gRPC size limit

### DIFF
--- a/events/errors/errors.go
+++ b/events/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -18,6 +19,7 @@ const (
 	ExecutionNotFound                ErrorCode = "ExecutionNotFound"
 	ResourceExhausted                ErrorCode = "ResourceExhausted"
 	InvalidArgument                  ErrorCode = "InvalidArgument"
+	TooLarge                         ErrorCode = "TooLarge"
 	EventSinkError                   ErrorCode = "EventSinkError"
 	EventAlreadyInTerminalStateError ErrorCode = "EventAlreadyInTerminalStateError"
 )
@@ -78,6 +80,10 @@ func WrapError(err error) error {
 	case codes.NotFound:
 		return wrapf(ExecutionNotFound, err, "The execution that the event belongs to does not exist")
 	case codes.ResourceExhausted:
+		if strings.Contains(statusErr.Message(), "message larger than max") {
+			return wrapf(TooLarge, err, "Message exceeds maximum size limit")
+		}
+
 		return wrapf(ResourceExhausted, err, "Events are sent too often, exceeded the rate limit")
 	case codes.InvalidArgument:
 		return wrapf(InvalidArgument, err, "Invalid fields for event message")
@@ -113,6 +119,11 @@ func IsNotFound(err error) bool {
 // Checks if the error is of type EventError and the ErrorCode is of type ResourceExhausted
 func IsResourceExhausted(err error) bool {
 	return errors.Is(err, &EventError{Code: ResourceExhausted})
+}
+
+// Checks if the error is of type EventError and the ErrorCode is of type TooLarge
+func IsTooLarge(err error) bool {
+	return errors.Is(err, &EventError{Code: TooLarge})
 }
 
 // Checks if the error is of type EventError and the ErrorCode is of type EventAlreadyInTerminalStateError

--- a/events/errors/errors.go
+++ b/events/errors/errors.go
@@ -81,7 +81,7 @@ func WrapError(err error) error {
 		return wrapf(ExecutionNotFound, err, "The execution that the event belongs to does not exist")
 	case codes.ResourceExhausted:
 		if strings.Contains(statusErr.Message(), "message larger than max") {
-			return wrapf(TooLarge, err, "Message exceeds maximum size limit")
+			return wrapf(TooLarge, err, "Event message exceeds maximum gRPC size limit")
 		}
 
 		return wrapf(ResourceExhausted, err, "Events are sent too often, exceeded the rate limit")

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -661,7 +661,6 @@ func (c *nodeExecutor) handleNode(ctx context.Context, dag executors.DAGStructur
 			return executors.NodeStatusUndefined, err
 		}
 		nodeStatus.UpdatePhase(v1alpha1.NodePhaseFailed, v1.Now(), nodeStatus.GetMessage(), nodeStatus.GetExecutionError())
-		// TODO - idempotent report event to transition node to failed state with flyteadmin?
 		c.metrics.FailureDuration.Observe(ctx, nodeStatus.GetStartedAt().Time, nodeStatus.GetStoppedAt().Time)
 		if nCtx.md.IsInterruptible() {
 			c.metrics.InterruptibleNodesTerminated.Inc(ctx)

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -578,7 +578,7 @@ func (c *nodeExecutor) handleQueuedOrRunningNode(ctx context.Context, nCtx *node
 		if err != nil {
 			if eventsErr.IsTooLarge(err) {
 				// With large enough dynamic task fanouts the reported node event, which contains the compiled
-				// workflow closure, can exceed the gRPC message size limit. In this case we immediately 
+				// workflow closure, can exceed the gRPC message size limit. In this case we immediately
 				// transition the node to failing to abort the workflow.
 				np = v1alpha1.NodePhaseFailing
 				p = handler.PhaseInfoFailure(core.ExecutionError_USER, "NodeFailed", err.Error(), p.GetInfo())


### PR DESCRIPTION
# TL;DR
Workflows with large dynamic task fanouts can exceed the gRPC message size limit when reporting the compiled workflow closure as a NodeEvent. This PR captures such errors and immediately transitions the node, and consequently the workflow, to failing with the following error message:

`TooLarge: Event message exceeds maximum gRPC size limit, caused by [rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5873232 vs. 4194304)]`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1613

## Follow-up issue
_NA_
