### PR TITLE
Handle incompatible cluster events errors

### DIFF
--- a/events/admin_eventsink_integration_test.go
+++ b/events/admin_eventsink_integration_test.go
@@ -6,10 +6,11 @@ package events
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	netUrl "net/url"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/flyteorg/flyteidl/clients/go/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"

--- a/events/errors/errors.go
+++ b/events/errors/errors.go
@@ -123,7 +123,7 @@ func IsEventAlreadyInTerminalStateError(err error) bool {
 	return errors.Is(err, &EventError{Code: EventAlreadyInTerminalStateError})
 }
 
-// Checks if the error is of type EventError and the ErrorCode is of type EventIncompatibleCusterError
+// IsEventIncompatibleClusterError checks if the error is of type EventError and the ErrorCode is of type EventIncompatibleCusterError
 func IsEventIncompatibleClusterError(err error) bool {
 	return errors.Is(err, &EventError{Code: EventIncompatibleCusterError})
 }

--- a/events/errors/errors.go
+++ b/events/errors/errors.go
@@ -20,7 +20,7 @@ const (
 	InvalidArgument                  ErrorCode = "InvalidArgument"
 	EventSinkError                   ErrorCode = "EventSinkError"
 	EventAlreadyInTerminalStateError ErrorCode = "EventAlreadyInTerminalStateError"
-	EventIncompatiblecCusterError ErrorCode = "EventIncompatibleClusterError"
+	EventIncompatibleCusterError     ErrorCode = "EventIncompatibleClusterError"
 )
 
 type EventError struct {
@@ -67,7 +67,7 @@ func WrapError(err error) error {
 					phase := reason.AlreadyInTerminalState.GetCurrentPhase()
 					return wrapf(EventAlreadyInTerminalStateError, err, fmt.Sprintf("conflicting events; destination: %v", phase))
 				case *admin.EventFailureReason_IncompatibleCluster:
-					return wrapf(EventIncompatiblecCusterError, err, fmt.Sprintf("conflicting execution cluster; expected: %v", reason.IncompatibleCluster.Cluster))
+					return wrapf(EventIncompatibleCusterError, err, fmt.Sprintf("conflicting execution cluster; expected: %v", reason.IncompatibleCluster.Cluster))
 				default:
 					logger.Warnf(context.Background(), "found unexpected type in details of grpc status: %v", reason)
 				}
@@ -123,7 +123,7 @@ func IsEventAlreadyInTerminalStateError(err error) bool {
 	return errors.Is(err, &EventError{Code: EventAlreadyInTerminalStateError})
 }
 
-// Checks if the error is of type EventError and the ErrorCode is of type EventIncompatiblecCusterError
-func IsEventIncompatiblecCusterError(err error) bool {
-	return errors.Is(err, &EventError{Code: EventIncompatiblecCusterError})
+// Checks if the error is of type EventError and the ErrorCode is of type EventIncompatibleCusterError
+func IsEventIncompatibleClusterError(err error) bool {
+	return errors.Is(err, &EventError{Code: EventIncompatibleCusterError})
 }

--- a/events/errors/errors.go
+++ b/events/errors/errors.go
@@ -20,6 +20,7 @@ const (
 	InvalidArgument                  ErrorCode = "InvalidArgument"
 	EventSinkError                   ErrorCode = "EventSinkError"
 	EventAlreadyInTerminalStateError ErrorCode = "EventAlreadyInTerminalStateError"
+	EventIncompatiblecCusterError ErrorCode = "EventIncompatibleClusterError"
 )
 
 type EventError struct {
@@ -65,6 +66,8 @@ func WrapError(err error) error {
 				case *admin.EventFailureReason_AlreadyInTerminalState:
 					phase := reason.AlreadyInTerminalState.GetCurrentPhase()
 					return wrapf(EventAlreadyInTerminalStateError, err, fmt.Sprintf("conflicting events; destination: %v", phase))
+				case *admin.EventFailureReason_IncompatibleCluster:
+					return wrapf(EventIncompatiblecCusterError, err, fmt.Sprintf("conflicting execution cluster; expected: %v", reason.IncompatibleCluster.Cluster))
 				default:
 					logger.Warnf(context.Background(), "found unexpected type in details of grpc status: %v", reason)
 				}
@@ -118,4 +121,9 @@ func IsResourceExhausted(err error) bool {
 // Checks if the error is of type EventError and the ErrorCode is of type EventAlreadyInTerminalStateError
 func IsEventAlreadyInTerminalStateError(err error) bool {
 	return errors.Is(err, &EventError{Code: EventAlreadyInTerminalStateError})
+}
+
+// Checks if the error is of type EventError and the ErrorCode is of type EventIncompatiblecCusterError
+func IsEventIncompatiblecCusterError(err error) bool {
+	return errors.Is(err, &EventError{Code: EventIncompatiblecCusterError})
 }

--- a/events/errors/errors_test.go
+++ b/events/errors/errors_test.go
@@ -44,6 +44,14 @@ func isUnknownError(err error) bool {
 
 // Test that we wrap the gRPC error to our correct one
 func TestWrapErrors(t *testing.T) {
+	incompatibleClusterErr, _ := status.New(codes.FailedPrecondition, "incompat").WithDetails(&admin.EventFailureReason{
+		Reason: &admin.EventFailureReason_IncompatibleCluster{
+			IncompatibleCluster: &admin.EventErrorIncompatibleCluster{
+				Cluster: "c1",
+			},
+		},
+	})
+
 	tests := []struct {
 		name         string
 		inputError   error
@@ -55,6 +63,7 @@ func TestWrapErrors(t *testing.T) {
 		{"uncaughtError", status.Error(codes.Unknown, "Unknown Err"), isEventError},
 		{"uncaughtError", fmt.Errorf("Random err"), isUnknownError},
 		{"errorWithReason", createTestErrorWithReason(), IsEventAlreadyInTerminalStateError},
+		{"incompatibleCluster", incompatibleClusterErr.Err(), IsEventIncompatibleClusterError},
 	}
 
 	for _, test := range tests {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DiSiqueira/GoTree v1.0.1-0.20180907134536-53a8e837f295
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
-	github.com/flyteorg/flyteidl v0.21.11
+	github.com/flyteorg/flyteidl v0.21.14-0.20211216005934-ab304d64bb4b
 	github.com/flyteorg/flyteplugins v0.9.1
 	github.com/flyteorg/flytestdlib v0.4.7
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DiSiqueira/GoTree v1.0.1-0.20180907134536-53a8e837f295
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.10.0
-	github.com/flyteorg/flyteidl v0.21.14-0.20211216005934-ab304d64bb4b
+	github.com/flyteorg/flyteidl v0.21.15
 	github.com/flyteorg/flyteplugins v0.9.1
 	github.com/flyteorg/flytestdlib v0.4.7
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flyteorg/flyteidl v0.21.11 h1:oH9YPoR7scO9GFF/I8D0gCTOB+JP5HRK7b7cLUBRz90=
 github.com/flyteorg/flyteidl v0.21.11/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.21.14-0.20211216005934-ab304d64bb4b h1:jkg30fG4YUzuRbiHg1QhFVyltKF67wecNT8hOQwhNlY=
+github.com/flyteorg/flyteidl v0.21.14-0.20211216005934-ab304d64bb4b/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.9.1 h1:Z0gxSvG7LeI+COfEmuzkhz9RnJ4E5wWUcjj5qh1uKuw=
 github.com/flyteorg/flyteplugins v0.9.1/go.mod h1:OEGQztPFDJG4DV7tS9lDsRRd521iUINn5dcsBf6bW5k=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=

--- a/go.sum
+++ b/go.sum
@@ -236,10 +236,9 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flyteorg/flyteidl v0.21.11 h1:oH9YPoR7scO9GFF/I8D0gCTOB+JP5HRK7b7cLUBRz90=
 github.com/flyteorg/flyteidl v0.21.11/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
-github.com/flyteorg/flyteidl v0.21.14-0.20211216005934-ab304d64bb4b h1:jkg30fG4YUzuRbiHg1QhFVyltKF67wecNT8hOQwhNlY=
-github.com/flyteorg/flyteidl v0.21.14-0.20211216005934-ab304d64bb4b/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.21.15 h1:XplSOL7Vl2dUriveXS27bnLhuNyAL+DR3sFexhFXrWE=
+github.com/flyteorg/flyteidl v0.21.15/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteplugins v0.9.1 h1:Z0gxSvG7LeI+COfEmuzkhz9RnJ4E5wWUcjj5qh1uKuw=
 github.com/flyteorg/flyteplugins v0.9.1/go.mod h1:OEGQztPFDJG4DV7tS9lDsRRd521iUINn5dcsBf6bW5k=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -108,6 +108,7 @@ var (
 		EventConfig: EventConfig{
 			RawOutputPolicy: RawOutputPolicyReference,
 		},
+		ClusterID: "propeller",
 	}
 )
 
@@ -143,6 +144,7 @@ type Config struct {
 	ExcludeProjectLabel    []string             `json:"exclude-project-label" pflag:",Exclude the specified project label from the k8s FlyteWorkflow CRD label selector"`
 	IncludeDomainLabel     []string             `json:"include-domain-label" pflag:",Include the specified domain label in the k8s FlyteWorkflow CRD label selector"`
 	ExcludeDomainLabel     []string             `json:"exclude-domain-label" pflag:",Exclude the specified domain label from the k8s FlyteWorkflow CRD label selector"`
+	ClusterID string `json:"cluster-id" pflag:",Unique cluster id running this flytepropeller instance with which to annotate execution events"`
 }
 
 // KubeClientConfig contains the configuration used by flytepropeller to configure its internal Kubernetes Client.

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -144,7 +144,7 @@ type Config struct {
 	ExcludeProjectLabel    []string             `json:"exclude-project-label" pflag:",Exclude the specified project label from the k8s FlyteWorkflow CRD label selector"`
 	IncludeDomainLabel     []string             `json:"include-domain-label" pflag:",Include the specified domain label in the k8s FlyteWorkflow CRD label selector"`
 	ExcludeDomainLabel     []string             `json:"exclude-domain-label" pflag:",Exclude the specified domain label from the k8s FlyteWorkflow CRD label selector"`
-	ClusterID string `json:"cluster-id" pflag:",Unique cluster id running this flytepropeller instance with which to annotate execution events"`
+	ClusterID              string               `json:"cluster-id" pflag:",Unique cluster id running this flytepropeller instance with which to annotate execution events"`
 }
 
 // KubeClientConfig contains the configuration used by flytepropeller to configure its internal Kubernetes Client.

--- a/pkg/controller/config/config_flags.go
+++ b/pkg/controller/config/config_flags.go
@@ -101,5 +101,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "exclude-project-label"), []string{}, "Exclude the specified project label from the k8s FlyteWorkflow CRD label selector")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "include-domain-label"), []string{}, "Include the specified domain label in the k8s FlyteWorkflow CRD label selector")
 	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "exclude-domain-label"), []string{}, "Exclude the specified domain label from the k8s FlyteWorkflow CRD label selector")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cluster-id"), defaultConfig.ClusterID, "Unique cluster id running this flytepropeller instance with which to annotate execution events")
 	return cmdFlags
 }

--- a/pkg/controller/config/config_flags_test.go
+++ b/pkg/controller/config/config_flags_test.go
@@ -813,4 +813,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_cluster-id", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("cluster-id", testValue)
+			if vString, err := cmdFlags.GetString("cluster-id"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.ClusterID)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -402,12 +402,12 @@ func New(ctx context.Context, cfg *config.Config, kubeclientset kubernetes.Inter
 
 	nodeExecutor, err := nodes.NewExecutor(ctx, cfg.NodeConfig, store, controller.enqueueWorkflowForNodeUpdates, eventSink,
 		launchPlanActor, launchPlanActor, cfg.MaxDatasetSizeBytes,
-		storage.DataReference(cfg.DefaultRawOutputPrefix), kubeClient, catalogClient, recovery.NewClient(adminClient), &cfg.EventConfig, scope)
+		storage.DataReference(cfg.DefaultRawOutputPrefix), kubeClient, catalogClient, recovery.NewClient(adminClient), &cfg.EventConfig, cfg.ClusterID, scope)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create Controller.")
 	}
 
-	workflowExecutor, err := workflow.NewExecutor(ctx, store, controller.enqueueWorkflowForNodeUpdates, eventSink, controller.recorder, cfg.MetadataPrefix, nodeExecutor, &cfg.EventConfig, scope)
+	workflowExecutor, err := workflow.NewExecutor(ctx, store, controller.enqueueWorkflowForNodeUpdates, eventSink, controller.recorder, cfg.MetadataPrefix, nodeExecutor, &cfg.EventConfig, cfg.ClusterID, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -131,7 +131,7 @@ func (p *Propeller) TryMutateWorkflow(ctx context.Context, originalW *v1alpha1.F
 		}()
 
 		if err != nil {
-			logger.Errorf(ctx, "Error when trying to reconcile workflow. Error [%v]. Error Type[%v]. Is nill [%v]",
+			logger.Errorf(ctx, "Error when trying to reconcile workflow. Error [%v]. Error Type[%v]",
 				err, reflect.TypeOf(err))
 			p.metrics.SystemError.Inc(ctx)
 			return nil, err

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -129,8 +129,9 @@ func (p *Propeller) TryMutateWorkflow(ctx context.Context, originalW *v1alpha1.F
 			}()
 			err = p.workflowExecutor.HandleFlyteWorkflow(ctx, mutableW)
 		}()
-
-		if err != nil {
+		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
+		// at this point in the clean-up.
+		if err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
 			logger.Errorf(ctx, "Error when trying to reconcile workflow. Error [%v]. Error Type[%v]",
 				err, reflect.TypeOf(err))
 			p.metrics.SystemError.Inc(ctx)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -129,9 +129,7 @@ func (p *Propeller) TryMutateWorkflow(ctx context.Context, originalW *v1alpha1.F
 			}()
 			err = p.workflowExecutor.HandleFlyteWorkflow(ctx, mutableW)
 		}()
-		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
-		// at this point in the clean-up.
-		if err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
+		if err != nil {
 			logger.Errorf(ctx, "Error when trying to reconcile workflow. Error [%v]. Error Type[%v]",
 				err, reflect.TypeOf(err))
 			p.metrics.SystemError.Inc(ctx)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -262,7 +262,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 			mutableW.Status.UpdatePhase(v1alpha1.WorkflowPhaseFailing, "Workflow execution cluster reassigned, aborting", &core.ExecutionError{
 				Kind:    core.ExecutionError_SYSTEM,
 				Code:    string(eventsErr.EventIncompatibleCusterError),
-				Message: "Workflow execution cluster reassigned.",
+				Message: fmt.Sprintf("Workflow execution cluster reassigned: %v", err.(*eventsErr.EventError).Error()),
 			})
 			if _, e := p.wfStore.Update(ctx, mutableW, workflowstore.PriorityClassCritical); e != nil {
 				logger.Errorf(ctx, "Failed to record an EventIncompatibleClusterError workflow as failed, reason: %s. Retrying...", e)

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -262,7 +262,7 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 			mutableW.Status.UpdatePhase(v1alpha1.WorkflowPhaseFailing, "Workflow execution cluster reassigned, aborting", &core.ExecutionError{
 				Kind:    core.ExecutionError_SYSTEM,
 				Code:    string(eventsErr.EventIncompatibleCusterError),
-				Message: fmt.Sprintf("Workflow execution cluster reassigned: %v", err.(*eventsErr.EventError).Error()),
+				Message: fmt.Sprintf("Workflow execution cluster reassigned: %v", err),
 			})
 			if _, e := p.wfStore.Update(ctx, mutableW, workflowstore.PriorityClassCritical); e != nil {
 				logger.Errorf(ctx, "Failed to record an EventIncompatibleClusterError workflow as failed, reason: %s. Retrying...", e)

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -1032,7 +1032,7 @@ func (c *nodeExecutor) AbortHandler(ctx context.Context, execContext executors.E
 			},
 			ProducerId: c.clusterID,
 		})
-		if err != nil {
+		if err != nil && !eventsErr.IsEventIncompatibleClusterError(err){
 			if errors2.IsCausedBy(err, errors.IllegalStateError) {
 				logger.Debugf(ctx, "Failed to record abort event due to illegal state transition. Ignoring the error. Error: %v", err)
 			} else {

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -101,7 +101,7 @@ type nodeExecutor struct {
 	shardSelector                   ioutils.ShardSelector
 	recoveryClient                  recovery.Client
 	eventConfig                     *config.EventConfig
-	clusterID string
+	clusterID                       string
 }
 
 func (c *nodeExecutor) RecordTransitionLatency(ctx context.Context, dag executors.DAGStructure, nl executors.NodeLookup, node v1alpha1.ExecutableNode, nodeStatus v1alpha1.ExecutableNodeStatus) {
@@ -149,10 +149,6 @@ func (c *nodeExecutor) IdempotentRecordEvent(ctx context.Context, nodeEvent *eve
 			}
 			logger.Warningf(ctx, "Failed to record nodeEvent, error [%s]", err.Error())
 			return errors.Wrapf(errors.IllegalStateError, nodeEvent.Id.NodeId, err, "phase mis-match mismatch between propeller and control plane; Trying to record Node p: %s", nodeEvent.Phase)
-		} else if eventsErr.IsEventIncompatiblecCusterError(err) {
-			// TODO: delete underlying execution
-			logger.Infof(ctx, "Node event on cluster: %s does not match cluster on record: %s", nodeEvent.ProducerId, err.Error())
-			return nil
 		}
 	}
 	return err
@@ -1133,7 +1129,7 @@ func NewExecutor(ctx context.Context, nodeConfig config.NodeConfig, store *stora
 		shardSelector:                   shardSelector,
 		recoveryClient:                  recoveryClient,
 		eventConfig:                     eventConfig,
-		clusterID: clusterID,
+		clusterID:                       clusterID,
 	}
 	nodeHandlerFactory, err := NewHandlerFactory(ctx, exec, workflowLauncher, launchPlanReader, kubeClient, catalogClient, recoveryClient, eventConfig, clusterID, nodeScope)
 	exec.nodeHandlerFactory = nodeHandlerFactory

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -1032,7 +1032,7 @@ func (c *nodeExecutor) AbortHandler(ctx context.Context, execContext executors.E
 			},
 			ProducerId: c.clusterID,
 		})
-		if err != nil && !eventsErr.IsEventIncompatibleClusterError(err){
+		if err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
 			if errors2.IsCausedBy(err, errors.IllegalStateError) {
 				logger.Debugf(ctx, "Failed to record abort event due to illegal state transition. Ignoring the error. Error: %v", err)
 			} else {

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -52,6 +52,7 @@ var recoveryClient = &recoveryMocks.RecoveryClient{}
 const taskID = "tID"
 const inputsPath = "inputs.pb"
 const outputsPath = "out/outputs.pb"
+const testClusterID = "C1"
 
 var eventConfig = &config.EventConfig{
 	RawOutputPolicy: config.RawOutputPolicyReference,
@@ -64,7 +65,7 @@ func TestSetInputsForStartNode(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	exec, err := NewExecutor(ctx, config.GetConfig().NodeConfig, mockStorage, enQWf, eventMocks.NewMockEventSink(), adminClient,
-		adminClient, 10, "s3://bucket/", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, 10, "s3://bucket/", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	inputs := &core.LiteralMap{
 		Literals: map[string]*core.Literal{
@@ -111,7 +112,7 @@ func TestSetInputsForStartNode(t *testing.T) {
 
 	failStorage := createFailingDatastore(t, testScope.NewSubScope("failing"))
 	execFail, err := NewExecutor(ctx, config.GetConfig().NodeConfig, failStorage, enQWf, eventMocks.NewMockEventSink(), adminClient,
-		adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	t.Run("StorageFailure", func(t *testing.T) {
 		w := createDummyBaseWorkflow(mockStorage)
@@ -137,7 +138,7 @@ func TestNodeExecutor_Initialize(t *testing.T) {
 
 	t.Run("happy", func(t *testing.T) {
 		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, memStore, enQWf, mockEventSink, adminClient,
-			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		exec := execIface.(*nodeExecutor)
 
@@ -151,7 +152,7 @@ func TestNodeExecutor_Initialize(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, memStore, enQWf, mockEventSink, adminClient,
-			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		exec := execIface.(*nodeExecutor)
 
@@ -174,7 +175,7 @@ func TestNodeExecutor_RecursiveNodeHandler_RecurseStartNodes(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient, adminClient,
-		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	exec := execIface.(*nodeExecutor)
 
@@ -278,7 +279,7 @@ func TestNodeExecutor_RecursiveNodeHandler_RecurseEndNode(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient, adminClient,
-		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	exec := execIface.(*nodeExecutor)
 
@@ -681,7 +682,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 
 				adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 				execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink,
-					adminClient, adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+					adminClient, adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 				assert.NoError(t, err)
 				exec := execIface.(*nodeExecutor)
 				exec.nodeHandlerFactory = hf
@@ -756,7 +757,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 				store := createInmemoryDataStore(t, promutils.NewTestScope())
 				adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 				execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
-					adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+					adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 				assert.NoError(t, err)
 				exec := execIface.(*nodeExecutor)
 				exec.nodeHandlerFactory = hf
@@ -867,7 +868,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 				store := createInmemoryDataStore(t, promutils.NewTestScope())
 				adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 				execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
-					adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+					adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 				assert.NoError(t, err)
 				exec := execIface.(*nodeExecutor)
 				exec.nodeHandlerFactory = hf
@@ -931,7 +932,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
-			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		exec := execIface.(*nodeExecutor)
 		exec.nodeHandlerFactory = hf
@@ -962,7 +963,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
-			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		exec := execIface.(*nodeExecutor)
 		exec.nodeHandlerFactory = hf
@@ -996,7 +997,7 @@ func TestNodeExecutor_RecursiveNodeHandler_NoDownstream(t *testing.T) {
 	store := createInmemoryDataStore(t, promutils.NewTestScope())
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
-		adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	exec := execIface.(*nodeExecutor)
 
@@ -1107,7 +1108,7 @@ func TestNodeExecutor_RecursiveNodeHandler_UpstreamNotReady(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient, adminClient,
-		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	exec := execIface.(*nodeExecutor)
 
@@ -1223,7 +1224,7 @@ func TestNodeExecutor_RecursiveNodeHandler_BranchNode(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient, adminClient,
-		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	exec := execIface.(*nodeExecutor)
 	// Node not yet started
@@ -1669,7 +1670,7 @@ func TestNodeExecutionEventStartNode(t *testing.T) {
 	nl.OnGetNodeExecutionStatusMatch(mock.Anything, id).Return(ns)
 	ns.OnGetParentTaskID().Return(tID)
 	ns.OnGetOutputDirMatch(mock.Anything).Return("dummy://dummyOutUrl")
-	ev, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion0, parentInfo, n)
+	ev, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion0, parentInfo, n, testClusterID)
 	assert.NoError(t, err)
 	assert.Equal(t, "start-node", ev.Id.NodeId)
 	assert.Equal(t, execID, ev.Id.ExecutionId)
@@ -1680,6 +1681,7 @@ func TestNodeExecutionEventStartNode(t *testing.T) {
 	assert.Empty(t, ev.RetryGroup)
 	assert.Equal(t, "dummy://dummyOutUrl/outputs.pb",
 		ev.OutputResult.(*event.NodeExecutionEvent_OutputUri).OutputUri)
+	assert.Equal(t, ev.ProducerId, testClusterID)
 }
 
 func TestNodeExecutionEventV0(t *testing.T) {
@@ -1709,7 +1711,7 @@ func TestNodeExecutionEventV0(t *testing.T) {
 	ns.OnGetPhase().Return(v1alpha1.NodePhaseNotYetStarted)
 	nl.OnGetNodeExecutionStatusMatch(mock.Anything, id).Return(ns)
 	ns.OnGetParentTaskID().Return(tID)
-	ev, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion0, parentInfo, n)
+	ev, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion0, parentInfo, n, testClusterID)
 	assert.NoError(t, err)
 	assert.Equal(t, "n1", ev.Id.NodeId)
 	assert.Equal(t, execID, ev.Id.ExecutionId)
@@ -1749,7 +1751,7 @@ func TestNodeExecutionEventV1(t *testing.T) {
 	ns.OnGetPhase().Return(v1alpha1.NodePhaseNotYetStarted)
 	nl.OnGetNodeExecutionStatusMatch(mock.Anything, id).Return(ns)
 	ns.OnGetParentTaskID().Return(tID)
-	eventOpt, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion1, parentInfo, n)
+	eventOpt, err := ToNodeExecutionEvent(nID, p, "reference", ns, v1alpha1.EventVersion1, parentInfo, n, testClusterID)
 	assert.NoError(t, err)
 	assert.Equal(t, "np1-2-n1", eventOpt.Id.NodeId)
 	assert.Equal(t, execID, eventOpt.Id.ExecutionId)
@@ -1773,7 +1775,7 @@ func TestNodeExecutor_RecursiveNodeHandler_ParallelismLimit(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient, adminClient,
-		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		10, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	exec := execIface.(*nodeExecutor)
 
@@ -1951,6 +1953,7 @@ func Test_nodeExecutor_IdempotentRecordEvent(t *testing.T) {
 			ev := &event.NodeExecutionEvent{
 				Id:    &core.NodeExecutionIdentifier{},
 				Phase: tt.p,
+				ProducerId: "propeller",
 			}
 			if err := c.IdempotentRecordEvent(context.TODO(), ev); (err != nil) != tt.wantErr {
 				t.Errorf("IdempotentRecordEvent() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1951,8 +1951,8 @@ func Test_nodeExecutor_IdempotentRecordEvent(t *testing.T) {
 				},
 			}
 			ev := &event.NodeExecutionEvent{
-				Id:    &core.NodeExecutionIdentifier{},
-				Phase: tt.p,
+				Id:         &core.NodeExecutionIdentifier{},
+				Phase:      tt.p,
 				ProducerId: "propeller",
 			}
 			if err := c.IdempotentRecordEvent(context.TODO(), ev); (err != nil) != tt.wantErr {

--- a/pkg/controller/nodes/handler_factory.go
+++ b/pkg/controller/nodes/handler_factory.go
@@ -56,9 +56,9 @@ func (f handlerFactory) Setup(ctx context.Context, setup handler.SetupContext) e
 
 func NewHandlerFactory(ctx context.Context, executor executors.Node, workflowLauncher launchplan.Executor,
 	launchPlanReader launchplan.Reader, kubeClient executors.Client, client catalog.Client, recoveryClient recovery.Client,
-	eventConfig *config.EventConfig, scope promutils.Scope) (HandlerFactory, error) {
+	eventConfig *config.EventConfig, clusterID string, scope promutils.Scope) (HandlerFactory, error) {
 
-	t, err := task.New(ctx, kubeClient, client, eventConfig, scope)
+	t, err := task.New(ctx, kubeClient, client, eventConfig, clusterID, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -3,9 +3,10 @@ package task
 import (
 	"context"
 	"fmt"
-	eventsErr "github.com/flyteorg/flytepropeller/events/errors"
 	"runtime/debug"
 	"time"
+
+	eventsErr "github.com/flyteorg/flytepropeller/events/errors"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
@@ -760,7 +761,7 @@ func (t Handler) Abort(ctx context.Context, nCtx handler.NodeExecutionContext, r
 				Code:    "Task Aborted",
 				Message: reason,
 			}},
-	}, t.eventConfig); err != nil && !eventsErr.IsEventIncompatibleClusterError(err){
+	}, t.eventConfig); err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
 		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
 		// at this point in the clean-up.
 		logger.Errorf(ctx, "failed to send event to Admin. error: %s", err.Error())

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -190,6 +190,7 @@ type Handler struct {
 	cfg             *config.Config
 	pluginScope     promutils.Scope
 	eventConfig     *controllerConfig.EventConfig
+	clusterID string
 }
 
 func (t *Handler) FinalizeRequired() bool {
@@ -640,6 +641,7 @@ func (t Handler) Handle(ctx context.Context, nCtx handler.NodeExecutionContext) 
 			TaskType:              ttype,
 			PluginID:              p.GetID(),
 			ResourcePoolInfo:      tCtx.rm.GetResourcePoolInfo(),
+			ClusterID: t.clusterID,
 		})
 		if err != nil {
 			return handler.UnknownTransition, err
@@ -663,6 +665,7 @@ func (t Handler) Handle(ctx context.Context, nCtx handler.NodeExecutionContext) 
 		TaskType:              ttype,
 		PluginID:              p.GetID(),
 		ResourcePoolInfo:      tCtx.rm.GetResourcePoolInfo(),
+		ClusterID: t.clusterID,
 	})
 	if err != nil {
 		logger.Errorf(ctx, "failed to convert plugin transition to TaskExecutionEvent. Error: %s", err.Error())
@@ -799,7 +802,7 @@ func (t Handler) Finalize(ctx context.Context, nCtx handler.NodeExecutionContext
 	}()
 }
 
-func New(ctx context.Context, kubeClient executors.Client, client catalog.Client, eventConfig *controllerConfig.EventConfig, scope promutils.Scope) (*Handler, error) {
+func New(ctx context.Context, kubeClient executors.Client, client catalog.Client, eventConfig *controllerConfig.EventConfig, clusterID string, scope promutils.Scope) (*Handler, error) {
 	// TODO New should take a pointer
 	async, err := catalog.NewAsyncClient(client, *catalog.GetConfig(), scope.NewSubScope("async_catalog"))
 	if err != nil {
@@ -841,5 +844,6 @@ func New(ctx context.Context, kubeClient executors.Client, client catalog.Client
 		barrierCache:    newLRUBarrier(ctx, cfg.BarrierConfig),
 		cfg:             cfg,
 		eventConfig:     eventConfig,
+		clusterID: clusterID,
 	}, nil
 }

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	eventsErr "github.com/flyteorg/flytepropeller/events/errors"
 	"runtime/debug"
 	"time"
 
@@ -759,7 +760,9 @@ func (t Handler) Abort(ctx context.Context, nCtx handler.NodeExecutionContext, r
 				Code:    "Task Aborted",
 				Message: reason,
 			}},
-	}, t.eventConfig); err != nil {
+	}, t.eventConfig); err != nil && !eventsErr.IsEventIncompatibleClusterError(err){
+		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
+		// at this point in the clean-up.
 		logger.Errorf(ctx, "failed to send event to Admin. error: %s", err.Error())
 		return err
 	}

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -190,7 +190,7 @@ type Handler struct {
 	cfg             *config.Config
 	pluginScope     promutils.Scope
 	eventConfig     *controllerConfig.EventConfig
-	clusterID string
+	clusterID       string
 }
 
 func (t *Handler) FinalizeRequired() bool {
@@ -641,7 +641,7 @@ func (t Handler) Handle(ctx context.Context, nCtx handler.NodeExecutionContext) 
 			TaskType:              ttype,
 			PluginID:              p.GetID(),
 			ResourcePoolInfo:      tCtx.rm.GetResourcePoolInfo(),
-			ClusterID: t.clusterID,
+			ClusterID:             t.clusterID,
 		})
 		if err != nil {
 			return handler.UnknownTransition, err
@@ -665,7 +665,7 @@ func (t Handler) Handle(ctx context.Context, nCtx handler.NodeExecutionContext) 
 		TaskType:              ttype,
 		PluginID:              p.GetID(),
 		ResourcePoolInfo:      tCtx.rm.GetResourcePoolInfo(),
-		ClusterID: t.clusterID,
+		ClusterID:             t.clusterID,
 	})
 	if err != nil {
 		logger.Errorf(ctx, "failed to convert plugin transition to TaskExecutionEvent. Error: %s", err.Error())
@@ -844,6 +844,6 @@ func New(ctx context.Context, kubeClient executors.Client, client catalog.Client
 		barrierCache:    newLRUBarrier(ctx, cfg.BarrierConfig),
 		cfg:             cfg,
 		eventConfig:     eventConfig,
-		clusterID: clusterID,
+		clusterID:       clusterID,
 	}, nil
 }

--- a/pkg/controller/nodes/task/handler_test.go
+++ b/pkg/controller/nodes/task/handler_test.go
@@ -55,6 +55,8 @@ var eventConfig = &controllerConfig.EventConfig{
 	RawOutputPolicy: controllerConfig.RawOutputPolicyReference,
 }
 
+const testClusterID = "C1"
+
 func Test_task_setDefault(t *testing.T) {
 	type fields struct {
 		defaultPlugin pluginCore.Plugin
@@ -244,7 +246,7 @@ func Test_task_Setup(t *testing.T) {
 			sCtx.On("EnqueueOwner").Return(pluginCore.EnqueueOwner(func(name types.NamespacedName) error { return nil }))
 			sCtx.On("MetricsScope").Return(promutils.NewTestScope())
 
-			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), &pluginCatalogMocks.Client{}, eventConfig, promutils.NewTestScope())
+			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), &pluginCatalogMocks.Client{}, eventConfig, testClusterID, promutils.NewTestScope())
 			tk.cfg.TaskPlugins.EnabledPlugins = tt.enabledPlugins
 			tk.cfg.TaskPlugins.DefaultForTaskTypes = tt.defaultForTaskTypes
 			assert.NoError(t, err)
@@ -903,7 +905,7 @@ func Test_task_Handle_Catalog(t *testing.T) {
 			} else {
 				c.OnPutMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(catalog.NewStatus(core.CatalogCacheStatus_CACHE_POPULATED, nil), nil)
 			}
-			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), c, eventConfig, promutils.NewTestScope())
+			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), c, eventConfig, testClusterID, promutils.NewTestScope())
 			assert.NoError(t, err)
 			tk.defaultPlugins = map[pluginCore.TaskType]pluginCore.Plugin{
 				"test": fakeplugins.NewPhaseBasedPlugin(),
@@ -1124,7 +1126,7 @@ func Test_task_Handle_Reservation(t *testing.T) {
 			}
 			c.OnPutMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(catalog.NewStatus(core.CatalogCacheStatus_CACHE_POPULATED, nil), nil)
 			c.OnGetOrExtendReservationMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&datacatalog.Reservation{OwnerId: tt.args.ownerID}, nil)
-			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), c, eventConfig, promutils.NewTestScope())
+			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), c, eventConfig, testClusterID, promutils.NewTestScope())
 			assert.NoError(t, err)
 			tk.defaultPlugins = map[pluginCore.TaskType]pluginCore.Plugin{
 				"test": fakeplugins.NewPhaseBasedPlugin(),
@@ -1403,7 +1405,7 @@ func Test_task_Handle_Barrier(t *testing.T) {
 			nCtx := createNodeContext(ev, "test", state, tt.args.prevTick)
 			c := &pluginCatalogMocks.Client{}
 
-			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), c, eventConfig, promutils.NewTestScope())
+			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), c, eventConfig, testClusterID, promutils.NewTestScope())
 			assert.NoError(t, err)
 			tk.resourceManager = noopRm
 
@@ -1908,7 +1910,7 @@ func Test_task_Finalize(t *testing.T) {
 			}
 
 			m := tt.fields.defaultPluginCallback()
-			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), catalog, eventConfig, promutils.NewTestScope())
+			tk, err := New(context.TODO(), mocks.NewFakeKubeClient(), catalog, eventConfig, testClusterID, promutils.NewTestScope())
 			assert.NoError(t, err)
 			tk.defaultPlugin = m
 			tk.resourceManager = noopRm
@@ -1927,7 +1929,7 @@ func Test_task_Finalize(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	got, err := New(context.TODO(), mocks.NewFakeKubeClient(), &pluginCatalogMocks.Client{}, eventConfig, promutils.NewTestScope())
+	got, err := New(context.TODO(), mocks.NewFakeKubeClient(), &pluginCatalogMocks.Client{}, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.NotNil(t, got.defaultPlugins)

--- a/pkg/controller/nodes/task/handler_test.go
+++ b/pkg/controller/nodes/task/handler_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	eventsErr "github.com/flyteorg/flytepropeller/events/errors"
+	mocks2 "github.com/flyteorg/flytepropeller/events/mocks"
+
 	"github.com/flyteorg/flytepropeller/events"
 
 	pluginK8sMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s/mocks"
@@ -1455,7 +1458,7 @@ func Test_task_Handle_Barrier(t *testing.T) {
 }
 
 func Test_task_Abort(t *testing.T) {
-	createNodeCtx := func(ev *fakeBufferedTaskEventRecorder) *nodeMocks.NodeExecutionContext {
+	createNodeCtx := func(ev events.TaskEventRecorder) *nodeMocks.NodeExecutionContext {
 		wfExecID := &core.WorkflowExecutionIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -1541,11 +1544,17 @@ func Test_task_Abort(t *testing.T) {
 
 	noopRm := CreateNoopResourceManager(context.TODO(), promutils.NewTestScope())
 
+	incompatibleClusterEventsRecorder := mocks2.TaskEventRecorder{}
+	incompatibleClusterEventsRecorder.OnRecordTaskEventMatch(mock.Anything, mock.Anything, mock.Anything).Return(
+		&eventsErr.EventError{
+			Code: eventsErr.EventIncompatibleCusterError,
+		})
+
 	type fields struct {
 		defaultPluginCallback func() pluginCore.Plugin
 	}
 	type args struct {
-		ev *fakeBufferedTaskEventRecorder
+		ev events.TaskEventRecorder
 	}
 	tests := []struct {
 		name        string
@@ -1572,6 +1581,13 @@ func Test_task_Abort(t *testing.T) {
 			p.On("Abort", mock.Anything, mock.Anything).Return(nil)
 			return p
 		}}, args{ev: &fakeBufferedTaskEventRecorder{}}, false, true},
+		{"abort-swallows-incompatible-cluster-err", fields{defaultPluginCallback: func() pluginCore.Plugin {
+			p := &pluginCoreMocks.Plugin{}
+			p.On("GetID").Return("id")
+			p.OnGetProperties().Return(pluginCore.PluginProperties{})
+			p.On("Abort", mock.Anything, mock.Anything).Return(nil)
+			return p
+		}}, args{ev: &incompatibleClusterEventsRecorder}, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1588,7 +1604,12 @@ func Test_task_Abort(t *testing.T) {
 			if tt.abortCalled {
 				c = 1
 				if !tt.wantErr {
-					assert.Len(t, tt.args.ev.evs, 1)
+					switch tt.args.ev.(type) {
+					case *fakeBufferedTaskEventRecorder:
+						assert.Len(t, tt.args.ev.(*fakeBufferedTaskEventRecorder).evs, 1)
+					case *mocks2.TaskEventRecorder:
+						assert.Len(t, tt.args.ev.(*mocks2.TaskEventRecorder).Calls, 1)
+					}
 				}
 			}
 			if m != nil {
@@ -1599,7 +1620,7 @@ func Test_task_Abort(t *testing.T) {
 }
 
 func Test_task_Abort_v1(t *testing.T) {
-	createNodeCtx := func(ev *fakeBufferedTaskEventRecorder) *nodeMocks.NodeExecutionContext {
+	createNodeCtx := func(ev events.TaskEventRecorder) *nodeMocks.NodeExecutionContext {
 		wfExecID := &core.WorkflowExecutionIdentifier{
 			Project: "project",
 			Domain:  "domain",
@@ -1685,11 +1706,17 @@ func Test_task_Abort_v1(t *testing.T) {
 
 	noopRm := CreateNoopResourceManager(context.TODO(), promutils.NewTestScope())
 
+	incompatibleClusterEventsRecorder := mocks2.TaskEventRecorder{}
+	incompatibleClusterEventsRecorder.OnRecordTaskEventMatch(mock.Anything, mock.Anything, mock.Anything).Return(
+		&eventsErr.EventError{
+			Code: eventsErr.EventIncompatibleCusterError,
+		})
+
 	type fields struct {
 		defaultPluginCallback func() pluginCore.Plugin
 	}
 	type args struct {
-		ev *fakeBufferedTaskEventRecorder
+		ev events.TaskEventRecorder
 	}
 	tests := []struct {
 		name        string
@@ -1716,6 +1743,13 @@ func Test_task_Abort_v1(t *testing.T) {
 			p.On("Abort", mock.Anything, mock.Anything).Return(nil)
 			return p
 		}}, args{ev: &fakeBufferedTaskEventRecorder{}}, false, true},
+		{"abort-swallows-incompatible-cluster-err", fields{defaultPluginCallback: func() pluginCore.Plugin {
+			p := &pluginCoreMocks.Plugin{}
+			p.On("GetID").Return("id")
+			p.OnGetProperties().Return(pluginCore.PluginProperties{})
+			p.On("Abort", mock.Anything, mock.Anything).Return(nil)
+			return p
+		}}, args{ev: &incompatibleClusterEventsRecorder}, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1732,7 +1766,12 @@ func Test_task_Abort_v1(t *testing.T) {
 			if tt.abortCalled {
 				c = 1
 				if !tt.wantErr {
-					assert.Len(t, tt.args.ev.evs, 1)
+					switch tt.args.ev.(type) {
+					case *fakeBufferedTaskEventRecorder:
+						assert.Len(t, tt.args.ev.(*fakeBufferedTaskEventRecorder).evs, 1)
+					case *mocks2.TaskEventRecorder:
+						assert.Len(t, tt.args.ev.(*mocks2.TaskEventRecorder).Calls, 1)
+					}
 				}
 			}
 			if m != nil {

--- a/pkg/controller/nodes/task/transformer.go
+++ b/pkg/controller/nodes/task/transformer.go
@@ -79,7 +79,7 @@ type ToTaskExecutionEventInputs struct {
 	TaskType              string
 	PluginID              string
 	ResourcePoolInfo      []*event.ResourcePoolInfo
-	ClusterID string
+	ClusterID             string
 }
 
 func ToTaskExecutionEvent(input ToTaskExecutionEventInputs) (*event.TaskExecutionEvent, error) {

--- a/pkg/controller/nodes/task/transformer.go
+++ b/pkg/controller/nodes/task/transformer.go
@@ -79,6 +79,7 @@ type ToTaskExecutionEventInputs struct {
 	TaskType              string
 	PluginID              string
 	ResourcePoolInfo      []*event.ResourcePoolInfo
+	ClusterID string
 }
 
 func ToTaskExecutionEvent(input ToTaskExecutionEventInputs) (*event.TaskExecutionEvent, error) {
@@ -111,7 +112,7 @@ func ToTaskExecutionEvent(input ToTaskExecutionEventInputs) (*event.TaskExecutio
 		RetryAttempt:          taskExecID.RetryAttempt,
 		Phase:                 ToTaskEventPhase(input.Info.Phase()),
 		PhaseVersion:          input.Info.Version(),
-		ProducerId:            "propeller",
+		ProducerId:            input.ClusterID,
 		OccurredAt:            tm,
 		InputUri:              input.InputReader.GetInputPath().String(),
 		TaskType:              input.TaskType,

--- a/pkg/controller/nodes/task/transformer_test.go
+++ b/pkg/controller/nodes/task/transformer_test.go
@@ -114,7 +114,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
-		ClusterID: testClusterID,
+		ClusterID:             testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Nil(t, tev.Logs)
@@ -151,7 +151,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
-		ClusterID: testClusterID,
+		ClusterID:             testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_RUNNING, tev.Phase)
@@ -186,7 +186,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
-		ClusterID: testClusterID,
+		ClusterID:             testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_SUCCEEDED, tev.Phase)
@@ -273,7 +273,7 @@ func TestToTaskExecutionEventWithParent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
-		ClusterID: testClusterID,
+		ClusterID:             testClusterID,
 	})
 	assert.NoError(t, err)
 	expectedNodeID := &core.NodeExecutionIdentifier{
@@ -313,7 +313,7 @@ func TestToTaskExecutionEventWithParent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
-		ClusterID: testClusterID,
+		ClusterID:             testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_RUNNING, tev.Phase)

--- a/pkg/controller/nodes/task/transformer_test.go
+++ b/pkg/controller/nodes/task/transformer_test.go
@@ -114,6 +114,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
+		ClusterID: testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Nil(t, tev.Logs)
@@ -130,6 +131,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, containerPluginIdentifier, tev.Metadata.PluginIdentifier)
 	assert.Equal(t, generatedName, tev.Metadata.GeneratedName)
 	assert.EqualValues(t, resourcePoolInfo, tev.Metadata.ResourcePoolInfo)
+	assert.Equal(t, testClusterID, tev.ProducerId)
 
 	l := []*core.TaskLog{
 		{Uri: "x", Name: "y", MessageFormat: core.TaskLog_JSON},
@@ -149,6 +151,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
+		ClusterID: testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_RUNNING, tev.Phase)
@@ -165,6 +168,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, containerPluginIdentifier, tev.Metadata.PluginIdentifier)
 	assert.Equal(t, generatedName, tev.Metadata.GeneratedName)
 	assert.EqualValues(t, resourcePoolInfo, tev.Metadata.ResourcePoolInfo)
+	assert.Equal(t, testClusterID, tev.ProducerId)
 
 	defaultNodeExecutionMetadata := handlerMocks.NodeExecutionMetadata{}
 	defaultNodeExecutionMetadata.OnIsInterruptible().Return(false)
@@ -182,6 +186,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
+		ClusterID: testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_SUCCEEDED, tev.Phase)
@@ -200,6 +205,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, containerPluginIdentifier, tev.Metadata.PluginIdentifier)
 	assert.Equal(t, generatedName, tev.Metadata.GeneratedName)
 	assert.EqualValues(t, resourcePoolInfo, tev.Metadata.ResourcePoolInfo)
+	assert.Equal(t, testClusterID, tev.ProducerId)
 }
 
 func TestToTransitionType(t *testing.T) {
@@ -267,6 +273,7 @@ func TestToTaskExecutionEventWithParent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
+		ClusterID: testClusterID,
 	})
 	assert.NoError(t, err)
 	expectedNodeID := &core.NodeExecutionIdentifier{
@@ -286,6 +293,7 @@ func TestToTaskExecutionEventWithParent(t *testing.T) {
 	assert.Equal(t, containerPluginIdentifier, tev.Metadata.PluginIdentifier)
 	assert.Equal(t, generatedName, tev.Metadata.GeneratedName)
 	assert.EqualValues(t, resourcePoolInfo, tev.Metadata.ResourcePoolInfo)
+	assert.Equal(t, testClusterID, tev.ProducerId)
 
 	l := []*core.TaskLog{
 		{Uri: "x", Name: "y", MessageFormat: core.TaskLog_JSON},
@@ -305,6 +313,7 @@ func TestToTaskExecutionEventWithParent(t *testing.T) {
 		TaskType:              containerTaskType,
 		PluginID:              containerPluginIdentifier,
 		ResourcePoolInfo:      resourcePoolInfo,
+		ClusterID: testClusterID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_RUNNING, tev.Phase)
@@ -321,4 +330,5 @@ func TestToTaskExecutionEventWithParent(t *testing.T) {
 	assert.Equal(t, containerPluginIdentifier, tev.Metadata.PluginIdentifier)
 	assert.Equal(t, generatedName, tev.Metadata.GeneratedName)
 	assert.EqualValues(t, resourcePoolInfo, tev.Metadata.ResourcePoolInfo)
+	assert.Equal(t, testClusterID, tev.ProducerId)
 }

--- a/pkg/controller/nodes/task_event_recorder.go
+++ b/pkg/controller/nodes/task_event_recorder.go
@@ -29,6 +29,10 @@ func (t taskEventRecorder) RecordTaskEvent(ctx context.Context, ev *event.TaskEx
 			}
 			logger.Warningf(ctx, "Failed to record taskEvent in state: %s, error: %s", ev.Phase, err)
 			return errors.Wrapf(err, "failed to record task event, as it already exists in terminal state. Event state: %s", ev.Phase)
+		} else if eventsErr.IsEventIncompatiblecCusterError(err) {
+			// TODO: delete underlying execution
+			logger.Infof(ctx, "Node event on cluster: %s does not match cluster on record: %s", ev.ProducerId, err.Error())
+			return nil
 		}
 		return err
 	}

--- a/pkg/controller/nodes/task_event_recorder.go
+++ b/pkg/controller/nodes/task_event_recorder.go
@@ -29,10 +29,6 @@ func (t taskEventRecorder) RecordTaskEvent(ctx context.Context, ev *event.TaskEx
 			}
 			logger.Warningf(ctx, "Failed to record taskEvent in state: %s, error: %s", ev.Phase, err)
 			return errors.Wrapf(err, "failed to record task event, as it already exists in terminal state. Event state: %s", ev.Phase)
-		} else if eventsErr.IsEventIncompatiblecCusterError(err) {
-			// TODO: delete underlying execution
-			logger.Infof(ctx, "Node event on cluster: %s does not match cluster on record: %s", ev.ProducerId, err.Error())
-			return nil
 		}
 		return err
 	}

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -76,7 +76,7 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 	status v1alpha1.ExecutableNodeStatus,
 	eventVersion v1alpha1.EventVersion,
 	parentInfo executors.ImmutableParentInfo,
-	node v1alpha1.ExecutableNode) (*event.NodeExecutionEvent, error) {
+	node v1alpha1.ExecutableNode, clusterID string) (*event.NodeExecutionEvent, error) {
 	if info.GetPhase() == handler.EPhaseNotReady {
 		return nil, nil
 	}
@@ -106,6 +106,7 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 				OutputURI: outputsFile,
 			}),
 			OccurredAt: occurredTime,
+			ProducerId: clusterID,
 		}
 	} else {
 		nev = &event.NodeExecutionEvent{
@@ -113,6 +114,7 @@ func ToNodeExecutionEvent(nodeExecID *core.NodeExecutionIdentifier,
 			Phase:      phase,
 			InputUri:   inputPath,
 			OccurredAt: occurredTime,
+			ProducerId: clusterID,
 		}
 	}
 

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -431,7 +431,7 @@ func (c *workflowExecutor) HandleFlyteWorkflow(ctx context.Context, w *v1alpha1.
 
 func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha1.FlyteWorkflow, maxRetries uint32) error {
 	w.DataReferenceConstructor = c.store
-
+	logger.Warnf(ctx, "Handling aborted workflow")
 	if !w.Status.IsTerminated() {
 		reason := fmt.Sprintf("max number of system retry attempts [%d/%d] exhausted - system failure.", w.Status.FailedAttempts, maxRetries)
 		c.metrics.IncompleteWorkflowAborted.Inc(ctx)
@@ -467,8 +467,9 @@ func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha
 				TransitionToPhase: v1alpha1.WorkflowPhaseAborted,
 			}
 		}
-
-		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, w.GetExecutionStatus(), status); err != nil {
+		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
+		// at this point in the clean-up.
+		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, w.GetExecutionStatus(), status); err != nil && !eventsErr.IsEventIncompatibleClusterError(err){
 			return err
 		}
 	}

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -340,6 +340,9 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 				logger.Warningf(ctx, msg)
 				wStatus.UpdatePhase(v1alpha1.WorkflowPhaseFailed, msg, nil)
 				return nil
+			} else if eventsErr.IsEventIncompatibleClusterError(recordingErr) {
+				logger.Infof(ctx, "Event recording failed due to [%+v]", recordingErr)
+				return recordingErr
 			}
 			logger.Warningf(ctx, "Event recording failed. Error [%s]", recordingErr.Error())
 			return errors.Wrapf(errors.EventRecordingError, "", recordingErr, "failed to publish event")

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -67,7 +67,7 @@ type workflowExecutor struct {
 	nodeExecutor    executors.Node
 	metrics         *workflowMetrics
 	eventConfig     *config.EventConfig
-	clusterID string
+	clusterID       string
 }
 
 func (c *workflowExecutor) constructWorkflowMetadataPrefix(ctx context.Context, w *v1alpha1.FlyteWorkflow) (storage.DataReference, error) {
@@ -271,7 +271,7 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 
 		wfEvent := &event.WorkflowExecutionEvent{
 			ExecutionId: execID,
-			ProducerId: c.clusterID,
+			ProducerId:  c.clusterID,
 		}
 		previousError := wStatus.GetExecutionError()
 		switch toStatus.TransitionToPhase {
@@ -339,10 +339,6 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 				msg := fmt.Sprintf("workflow state mismatch between propeller and control plane; Propeller State: %s, ExecutionId %s", wfEvent.Phase.String(), wfEvent.ExecutionId)
 				logger.Warningf(ctx, msg)
 				wStatus.UpdatePhase(v1alpha1.WorkflowPhaseFailed, msg, nil)
-				return nil
-			} else if eventsErr.IsEventIncompatiblecCusterError(recordingErr) {
-				// TODO: delete underlying execution
-				logger.Infof(ctx, "Node event on cluster: %s does not match cluster on record: %s", wfEvent.ProducerId, recordingErr.Error())
 				return nil
 			}
 			logger.Warningf(ctx, "Event recording failed. Error [%s]", recordingErr.Error())
@@ -517,7 +513,7 @@ func NewExecutor(ctx context.Context, store *storage.DataStore, enQWorkflow v1al
 		metadataPrefix:  basePrefix,
 		metrics:         newMetrics(workflowScope),
 		eventConfig:     eventConfig,
-		clusterID: clusterID,
+		clusterID:       clusterID,
 	}, nil
 }
 

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -474,9 +474,6 @@ func (c *workflowExecutor) HandleAbortedWorkflow(ctx context.Context, w *v1alpha
 			}
 		}
 		if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, w.GetExecutionStatus(), status); err != nil {
-		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
-		// at this point in the clean-up.
-		//if err := c.TransitionToPhase(ctx, w.ExecutionID.WorkflowExecutionIdentifier, w.GetExecutionStatus(), status); err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
 			return err
 		}
 	}

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -341,7 +341,8 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 				wStatus.UpdatePhase(v1alpha1.WorkflowPhaseFailed, msg, nil)
 				return nil
 			}
-			if wfEvent.Phase == core.WorkflowExecution_FAILING && eventsErr.IsEventIncompatibleClusterError(recordingErr) {
+			if (wfEvent.Phase == core.WorkflowExecution_FAILING || wfEvent.Phase == core.WorkflowExecution_FAILED) &&
+				eventsErr.IsEventIncompatibleClusterError(recordingErr) {
 				// Don't stall the workflow transition to failed (so that resources can be cleaned up) since the events
 				// are being discarded by the back-end anyways.
 				logger.Infof(ctx, "Failed to record failing workflowEvent, error [%s]. Ignoring this error!", recordingErr.Error())

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -340,9 +340,6 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 				logger.Warningf(ctx, msg)
 				wStatus.UpdatePhase(v1alpha1.WorkflowPhaseFailed, msg, nil)
 				return nil
-			} else if eventsErr.IsEventIncompatibleClusterError(recordingErr) {
-				logger.Infof(ctx, "Event recording failed due to [%+v]", recordingErr)
-				return recordingErr
 			}
 			logger.Warningf(ctx, "Event recording failed. Error [%s]", recordingErr.Error())
 			return errors.Wrapf(errors.EventRecordingError, "", recordingErr, "failed to publish event")

--- a/pkg/controller/workflow/executor_test.go
+++ b/pkg/controller/workflow/executor_test.go
@@ -60,6 +60,7 @@ var (
 
 const (
 	maxOutputSize = 10 * 1024
+	testClusterID = "C1"
 )
 
 var eventConfig = &config.EventConfig{
@@ -243,9 +244,9 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_Error(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	nodeExec, err := nodes.NewExecutor(ctx, config.GetConfig().NodeConfig, store, enqueueWorkflow, eventSink, adminClient,
-		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
-	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, promutils.NewTestScope())
+	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 
 	assert.NoError(t, executor.Initialize(ctx))
@@ -323,10 +324,10 @@ func TestWorkflowExecutor_HandleFlyteWorkflow(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	nodeExec, err := nodes.NewExecutor(ctx, config.GetConfig().NodeConfig, store, enqueueWorkflow, eventSink, adminClient,
-		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 
-	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, promutils.NewTestScope())
+	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 
 	assert.NoError(t, executor.Initialize(ctx))
@@ -386,10 +387,10 @@ func BenchmarkWorkflowExecutor(b *testing.B) {
 	recoveryClient := &recoveryMocks.RecoveryClient{}
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	nodeExec, err := nodes.NewExecutor(ctx, config.GetConfig().NodeConfig, store, enqueueWorkflow, eventSink, adminClient,
-		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, scope)
+		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, scope)
 	assert.NoError(b, err)
 
-	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, promutils.NewTestScope())
+	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(b, err)
 
 	assert.NoError(b, executor.Initialize(ctx))
@@ -469,18 +470,21 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_Failing(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.WithinDuration(t, occuredAt, time.Now(), time.Millisecond*5)
+				assert.Equal(t, testClusterID, e.ProducerId)
 				recordedRunning = true
 			case core.WorkflowExecution_FAILING:
 				occuredAt, err := ptypes.Timestamp(e.OccurredAt)
 				assert.NoError(t, err)
 
 				assert.WithinDuration(t, occuredAt, time.Now(), time.Millisecond*5)
+				assert.Equal(t, testClusterID, e.ProducerId)
 				recordedFailing = true
 			case core.WorkflowExecution_FAILED:
 				occuredAt, err := ptypes.Timestamp(e.OccurredAt)
 				assert.NoError(t, err)
 
 				assert.WithinDuration(t, occuredAt, time.Now(), time.Millisecond*5)
+				assert.Equal(t, testClusterID, e.ProducerId)
 				recordedFailed = true
 			default:
 				return fmt.Errorf("MockWorkflowRecorder should not have entered into any other states [%v]", e.Phase)
@@ -493,9 +497,9 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_Failing(t *testing.T) {
 	recoveryClient := &recoveryMocks.RecoveryClient{}
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	nodeExec, err := nodes.NewExecutor(ctx, config.GetConfig().NodeConfig, store, enqueueWorkflow, eventSink, adminClient,
-		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
-	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, promutils.NewTestScope())
+	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 
 	assert.NoError(t, executor.Initialize(ctx))
@@ -562,18 +566,21 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_Events(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.WithinDuration(t, occuredAt, time.Now(), time.Millisecond*5)
+				assert.Equal(t, testClusterID, e.ProducerId)
 				recordedRunning = true
 			case core.WorkflowExecution_SUCCEEDING:
 				occuredAt, err := ptypes.Timestamp(e.OccurredAt)
 				assert.NoError(t, err)
 
 				assert.WithinDuration(t, occuredAt, time.Now(), time.Millisecond*5)
+				assert.Equal(t, testClusterID, e.ProducerId)
 				recordedFailing = true
 			case core.WorkflowExecution_SUCCEEDED:
 				occuredAt, err := ptypes.Timestamp(e.OccurredAt)
 				assert.NoError(t, err)
 
 				assert.WithinDuration(t, occuredAt, time.Now(), time.Millisecond*5)
+				assert.Equal(t, testClusterID, e.ProducerId)
 				recordedSuccess = true
 			default:
 				return fmt.Errorf("MockWorkflowRecorder should not have entered into any other states, received [%v]", e.Phase.String())
@@ -586,9 +593,9 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_Events(t *testing.T) {
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	recoveryClient := &recoveryMocks.RecoveryClient{}
 	nodeExec, err := nodes.NewExecutor(ctx, config.GetConfig().NodeConfig, store, enqueueWorkflow, eventSink, adminClient,
-		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
-	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, promutils.NewTestScope())
+	executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 
 	assert.NoError(t, executor.Initialize(ctx))
@@ -644,7 +651,7 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_EventFailure(t *testing.T) {
 
 	adminClient := launchplan.NewFailFastLaunchPlanExecutor()
 	nodeExec, err := nodes.NewExecutor(ctx, config.GetConfig().NodeConfig, store, enqueueWorkflow, nodeEventSink, adminClient,
-		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, promutils.NewTestScope())
+		adminClient, maxOutputSize, "s3://bucket", fakeKubeClient, catalogClient, recoveryClient, eventConfig, testClusterID, promutils.NewTestScope())
 	assert.NoError(t, err)
 
 	t.Run("EventAlreadyInTerminalStateError", func(t *testing.T) {
@@ -655,7 +662,7 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_EventFailure(t *testing.T) {
 				Cause: errors.New("already exists"),
 			}
 		}
-		executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, promutils.NewTestScope())
+		executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		w := &v1alpha1.FlyteWorkflow{}
 		assert.NoError(t, json.Unmarshal(wJSON, w))
@@ -674,7 +681,7 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_EventFailure(t *testing.T) {
 				Cause: errors.New("already exists"),
 			}
 		}
-		executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, promutils.NewTestScope())
+		executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		w := &v1alpha1.FlyteWorkflow{}
 		assert.NoError(t, json.Unmarshal(wJSON, w))
@@ -690,7 +697,7 @@ func TestWorkflowExecutor_HandleFlyteWorkflow_EventFailure(t *testing.T) {
 				Cause: errors.New("generic exists"),
 			}
 		}
-		executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, promutils.NewTestScope())
+		executor, err := NewExecutor(ctx, store, enqueueWorkflow, eventSink, recorder, "metadata", nodeExec, eventConfig, testClusterID, promutils.NewTestScope())
 		assert.NoError(t, err)
 		w := &v1alpha1.FlyteWorkflow{}
 		assert.NoError(t, json.Unmarshal(wJSON, w))
@@ -739,6 +746,7 @@ func TestWorkflowExecutor_HandleAbortedWorkflow(t *testing.T) {
 		nodeExec := &mocks2.Node{}
 		wfRecorder := &eventMocks.WorkflowEventRecorder{}
 		wfRecorder.On("RecordWorkflowEvent", mock.Anything, mock.MatchedBy(func(ev *event.WorkflowExecutionEvent) bool {
+			assert.Equal(t, testClusterID, ev.ProducerId)
 			evs = append(evs, ev)
 			return true
 		}), mock.Anything).Return(nil)
@@ -749,6 +757,7 @@ func TestWorkflowExecutor_HandleAbortedWorkflow(t *testing.T) {
 			eventConfig: &config.EventConfig{
 				RawOutputPolicy: config.RawOutputPolicyReference,
 			},
+			clusterID: testClusterID,
 		}
 
 		nodeExec.OnAbortHandlerMatch(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -779,6 +788,7 @@ func TestWorkflowExecutor_HandleAbortedWorkflow(t *testing.T) {
 		nodeExec := &mocks2.Node{}
 		wfRecorder := &eventMocks.WorkflowEventRecorder{}
 		wfRecorder.OnRecordWorkflowEventMatch(mock.Anything, mock.MatchedBy(func(ev *event.WorkflowExecutionEvent) bool {
+			assert.Equal(t, testClusterID, ev.ProducerId)
 			evs = append(evs, ev)
 			return true
 		}), mock.Anything).Return(nil)
@@ -789,6 +799,7 @@ func TestWorkflowExecutor_HandleAbortedWorkflow(t *testing.T) {
 			eventConfig: &config.EventConfig{
 				RawOutputPolicy: config.RawOutputPolicyReference,
 			},
+			clusterID: testClusterID,
 		}
 
 		nodeExec.OnAbortHandlerMatch(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -818,6 +829,7 @@ func TestWorkflowExecutor_HandleAbortedWorkflow(t *testing.T) {
 		nodeExec := &mocks2.Node{}
 		wfRecorder := &eventMocks.WorkflowEventRecorder{}
 		wfRecorder.OnRecordWorkflowEventMatch(mock.Anything, mock.MatchedBy(func(ev *event.WorkflowExecutionEvent) bool {
+			assert.Equal(t, testClusterID, ev.ProducerId)
 			evs = append(evs, ev)
 			return true
 		}), mock.Anything).Return(nil)
@@ -828,6 +840,7 @@ func TestWorkflowExecutor_HandleAbortedWorkflow(t *testing.T) {
 			eventConfig: &config.EventConfig{
 				RawOutputPolicy: config.RawOutputPolicyReference,
 			},
+			clusterID: testClusterID,
 		}
 
 		nodeExec.OnAbortHandlerMatch(ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
# TL;DR
At some point during workflow execution a scenario may arise when the cluster assigned to an execution is updated. This change introduces failure handling to early abort such workflows still running on the original cluster. IncompatibleCluster errors as they are first received are propagated to the workflow executor which transitions the workflow to failing to clean up resources. This leads to Abort handler calls for running tasks and nodes which swallow event recording failures due to subsequent (and expected) IncompatibleCluster errors.

### Testing
Verified that the workflow CRD metadata ends up with `termination-status: terminated` for IncompatibleCluster errors sent initially for
- Workflow execution events
- Node execution events
- Task execution events 
- Subworkflows
- Child workflows
- Branch nodes

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
See tracking issue for context

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1929

## Follow-up issue
_NA_
