### PR TITLE
Add templating functionality to AddObjectMetadata

### DIFF
--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -115,11 +115,11 @@ func InjectTemplates(taskCtx pluginsCore.TaskExecutionMetadata, defaults map[str
 
 	var templated = make(map[string]string)
 	for k, v := range defaults {
-		var kTemplated = string(k)
+		var kTemplated = k
 		kTemplated = strings.Replace(kTemplated, templateDomainVariable, domain, replaceAllInstancesOfString)
 		kTemplated = strings.Replace(kTemplated, templateProjectVariable, project, replaceAllInstancesOfString)
 
-		var vTemplated = string(v)
+		var vTemplated = v
 		vTemplated = strings.Replace(vTemplated, templateDomainVariable, domain, replaceAllInstancesOfString)
 		vTemplated = strings.Replace(vTemplated, templateProjectVariable, project, replaceAllInstancesOfString)
 		templated[kTemplated] = vTemplated

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -106,6 +106,9 @@ type PluginManager struct {
 	resourceLevelMonitor *ResourceLevelMonitor
 }
 
+// Handles dynamic templating of DefaultAnnotations and DefaultLabels to replace placeholders {{ PROJECT }} and {{ DOMAIN }}
+// with there actual values at execution time. This is useful if one wants to add custom IAM roles or Vault roles to task pods
+// depending on the project and domain.
 func InjectTemplates(taskCtx pluginsCore.TaskExecutionMetadata, defaults map[string]string) map[string]string {
 	execId := taskCtx.GetTaskExecutionID().GetID().NodeExecutionId.GetExecutionId()
 	project := execId.GetProject()

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -238,12 +238,12 @@ func getMockTaskExecutionMetadataCustomTemplate(project string, domain string) p
 	taskExecutionMetadata.On("GetLabels").Return(nil)
 	taskExecutionMetadata.On("GetOwnerReference").Return(v12.OwnerReference{Name: "x"})
 
-	wfExecId := &core.WorkflowExecutionIdentifier{
+	wfExecID := &core.WorkflowExecutionIdentifier{
 		Project: project,
 		Domain:  domain,
 	}
 	nodeExecId := &core.NodeExecutionIdentifier{
-		ExecutionId: wfExecId,
+		ExecutionId: wfExecID,
 	}
 	id := &pluginsCoreMock.TaskExecutionID{}
 	id.On("GetID").Return(core.TaskExecutionIdentifier{

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -242,12 +242,12 @@ func getMockTaskExecutionMetadataCustomTemplate(project string, domain string) p
 		Project: project,
 		Domain:  domain,
 	}
-	nodeExecId := &core.NodeExecutionIdentifier{
+	nodeExecID := &core.NodeExecutionIdentifier{
 		ExecutionId: wfExecID,
 	}
 	id := &pluginsCoreMock.TaskExecutionID{}
 	id.On("GetID").Return(core.TaskExecutionIdentifier{
-		NodeExecutionId: nodeExecId,
+		NodeExecutionId: nodeExecID,
 	})
 	id.On("GetGeneratedName").Return("test")
 	taskExecutionMetadata.On("GetTaskExecutionID").Return(id)


### PR DESCRIPTION
# TL;DR
Implements https://github.com/flyteorg/flyte/issues/1592 for `DefaultAnnotations` and `DefaultLabels`

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Adds a new function `InjectTemplates` which is called inside `AddObjectMetadata`. 
The functions retrieves the current `project` and `domain` by traversing the `TaskExecutionMetadata`. It then first marshalls the objects selected for templating into yaml, performs string replacement of the placeholders and unmarshalls that yaml back. Admittedly slightly hacky, would be curious to learn a better way!


Tests are added, smoke testing was already done successfully on our Flyte dev cluster.  

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1592

## Follow-up issue
_NA_