### PR TITLE
A new metrics scope per plugin is created

### DIFF
--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -235,7 +235,7 @@ func (t *Handler) Setup(ctx context.Context, sCtx handler.SetupContext) error {
 		// create a new resource registrar proxy for each plugin, and pass it into the plugin's LoadPlugin() via a setup context
 		pluginResourceNamespacePrefix := pluginCore.ResourceNamespace(newResourceManagerBuilder.GetID()).CreateSubNamespace(pluginCore.ResourceNamespace(p.ID))
 		sCtxFinal := newNameSpacedSetupCtx(
-			tSCtx, newResourceManagerBuilder.GetResourceRegistrar(pluginResourceNamespacePrefix))
+			tSCtx, newResourceManagerBuilder.GetResourceRegistrar(pluginResourceNamespacePrefix), p.ID)
 		logger.Infof(ctx, "Loading Plugin [%s] ENABLED", p.ID)
 		cp, err := pluginCore.LoadPlugin(ctx, sCtxFinal, p)
 		if err != nil {

--- a/pkg/controller/nodes/task/setup_ctx.go
+++ b/pkg/controller/nodes/task/setup_ctx.go
@@ -40,7 +40,7 @@ func (t *Handler) newSetupContext(sCtx handler.SetupContext) *setupContext {
 
 type nameSpacedSetupCtx struct {
 	*setupContext
-	rn pluginCore.ResourceRegistrar
+	rn       pluginCore.ResourceRegistrar
 	pluginID string
 }
 

--- a/pkg/controller/nodes/task/setup_ctx.go
+++ b/pkg/controller/nodes/task/setup_ctx.go
@@ -18,10 +18,6 @@ func (s setupContext) SecretManager() pluginCore.SecretManager {
 	return s.secretManager
 }
 
-func (s setupContext) MetricsScope() promutils.Scope {
-	return s.SetupContext.MetricsScope()
-}
-
 func (s setupContext) KubeClient() pluginCore.KubeClient {
 	return s.kubeClient
 }
@@ -45,15 +41,21 @@ func (t *Handler) newSetupContext(sCtx handler.SetupContext) *setupContext {
 type nameSpacedSetupCtx struct {
 	*setupContext
 	rn pluginCore.ResourceRegistrar
+	pluginID string
 }
 
 func (n nameSpacedSetupCtx) ResourceRegistrar() pluginCore.ResourceRegistrar {
 	return n.rn
 }
 
-func newNameSpacedSetupCtx(sCtx *setupContext, rn pluginCore.ResourceRegistrar) nameSpacedSetupCtx {
+func (n nameSpacedSetupCtx) MetricsScope() promutils.Scope {
+	return n.SetupContext.MetricsScope().NewSubScope(n.pluginID)
+}
+
+func newNameSpacedSetupCtx(sCtx *setupContext, rn pluginCore.ResourceRegistrar, pluginID string) nameSpacedSetupCtx {
 	return nameSpacedSetupCtx{
 		setupContext: sCtx,
 		rn:           rn,
+		pluginID:     pluginID,
 	}
 }

--- a/pkg/controller/nodes/task/setup_ctx_test.go
+++ b/pkg/controller/nodes/task/setup_ctx_test.go
@@ -1,0 +1,27 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/handler"
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/stretchr/testify/assert"
+)
+
+type dummySetupCtx struct {
+	handler.SetupContext
+	testScopeName string
+}
+
+func (d dummySetupCtx) MetricsScope() promutils.Scope {
+	return promutils.NewScope(d.testScopeName)
+}
+
+func Test_nameSpacedSetupCtx_MetricsScope(t *testing.T) {
+	r := &mocks.ResourceRegistrar{}
+	ns := newNameSpacedSetupCtx(&setupContext{SetupContext: &dummySetupCtx{testScopeName: "test-scope-1"}}, r, "p1")
+	scope := ns.MetricsScope()
+	assert.NotNil(t, scope)
+	assert.Equal(t, "test-scope-1:p1:", scope.CurrentScope())
+}


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Creates a new metrics scope per plugin. This allows every plugin to create the same metrics if needed

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2136

## Follow-up issue
_NA_

