### PR TITLE
StructuredDataset without column should be castable to StructuredDataset with columns

### DIFF
--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -163,7 +163,7 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 
 // Upstream (schema) -> downstream (schema)
 func schemaCastFromSchema(upstream *flyte.SchemaType, downstream *flyte.SchemaType) bool {
-	if len(downstream.Columns) == 0 {
+	if len(upstream.Columns) == 0 || len(downstream.Columns) == 0 {
 		return true
 	}
 
@@ -187,7 +187,7 @@ func schemaCastFromSchema(upstream *flyte.SchemaType, downstream *flyte.SchemaTy
 
 // Upstream (structuredDatasetType) -> downstream (structuredDatasetType)
 func structuredDatasetCastFromStructuredDataset(upstream *flyte.StructuredDatasetType, downstream *flyte.StructuredDatasetType) bool {
-	if len(downstream.Columns) == 0 {
+	if len(upstream.Columns) == 0 || len(downstream.Columns) == 0 {
 		return true
 	}
 
@@ -211,7 +211,7 @@ func structuredDatasetCastFromStructuredDataset(upstream *flyte.StructuredDatase
 
 // Upstream (schemaType) -> downstream (structuredDatasetType)
 func structuredDatasetCastFromSchema(upstream *flyte.SchemaType, downstream *flyte.StructuredDatasetType) bool {
-	if len(downstream.Columns) == 0 {
+	if len(upstream.Columns) == 0 || len(downstream.Columns) == 0 {
 		return true
 	}
 	nameToTypeMap := make(map[string]flyte.SchemaType_SchemaColumn_SchemaColumnType)
@@ -234,7 +234,7 @@ func structuredDatasetCastFromSchema(upstream *flyte.SchemaType, downstream *fly
 
 // Upstream (structuredDatasetType) -> downstream (schemaType)
 func schemaCastFromStructuredDataset(upstream *flyte.StructuredDatasetType, downstream *flyte.SchemaType) bool {
-	if len(downstream.Columns) == 0 {
+	if len(upstream.Columns) == 0 || len(downstream.Columns) == 0 {
 		return true
 	}
 	nameToTypeMap := make(map[string]flyte.SimpleType)

--- a/pkg/compiler/validators/typing_test.go
+++ b/pkg/compiler/validators/typing_test.go
@@ -411,7 +411,7 @@ func TestSchemaCasting(t *testing.T) {
 
 	t.Run("GenericSchemaToNonGeneric", func(t *testing.T) {
 		castable := AreTypesCastable(genericSchema, subsetIntegerSchema)
-		assert.False(t, castable, "Schema() should not be castable to Schema(a=Integer)")
+		assert.True(t, castable, "Schema() should be castable to Schema(a=Integer)")
 	})
 
 	t.Run("NonGenericSchemaToGeneric", func(t *testing.T) {
@@ -548,7 +548,7 @@ func TestStructuredDatasetCasting(t *testing.T) {
 
 	t.Run("GenericStructuredDatasetToNonGeneric", func(t *testing.T) {
 		castable := AreTypesCastable(genericStructuredDataset, subsetStructuredDataset)
-		assert.False(t, castable, "StructuredDataset() should not be castable to StructuredDataset(a=Integer, b=Collection)")
+		assert.True(t, castable, "StructuredDataset() should be castable to StructuredDataset(a=Integer, b=Collection)")
 	})
 
 	t.Run("NonGenericStructuredDatasetToGeneric", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Upstream sd without column should be castable to sd with columns.
For example, the following task should be successfully compiled by the propeller. 

```python
@task
def to_numpy(ds: StructuredDataset) -> Annotated[StructuredDataset, cols, PARQUET]:
    numpy_array = ds.open(np.ndarray).all()
    return StructuredDataset(dataframe=numpy_array)
```

@task
def t1()

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2074

## Follow-up issue
_NA_