### PR TITLE
metric names cannot have hyphens

### DIFF
--- a/pkg/controller/nodes/task/setup_ctx.go
+++ b/pkg/controller/nodes/task/setup_ctx.go
@@ -4,6 +4,7 @@ import (
 	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"k8s.io/apimachinery/pkg/types"
+	"strings"
 
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/handler"
 )
@@ -49,7 +50,8 @@ func (n nameSpacedSetupCtx) ResourceRegistrar() pluginCore.ResourceRegistrar {
 }
 
 func (n nameSpacedSetupCtx) MetricsScope() promutils.Scope {
-	return n.SetupContext.MetricsScope().NewSubScope(n.pluginID)
+	p := strings.Replace(n.pluginID, "-", "_", -1)
+	return n.SetupContext.MetricsScope().NewSubScope(p)
 }
 
 func newNameSpacedSetupCtx(sCtx *setupContext, rn pluginCore.ResourceRegistrar, pluginID string) nameSpacedSetupCtx {

--- a/pkg/controller/nodes/task/setup_ctx_test.go
+++ b/pkg/controller/nodes/task/setup_ctx_test.go
@@ -25,3 +25,11 @@ func Test_nameSpacedSetupCtx_MetricsScope(t *testing.T) {
 	assert.NotNil(t, scope)
 	assert.Equal(t, "test-scope-1:p1:", scope.CurrentScope())
 }
+
+func Test_nameSpacedSetupCtx_MetricsScope_unsafe(t *testing.T) {
+	r := &mocks.ResourceRegistrar{}
+	ns := newNameSpacedSetupCtx(&setupContext{SetupContext: &dummySetupCtx{testScopeName: "test-scope-1"}}, r, "k8s-array")
+	scope := ns.MetricsScope()
+	assert.NotNil(t, scope)
+	assert.Equal(t, "test-scope-1:k8s_array:", scope.CurrentScope())
+}


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Metric names cannot have hyphens

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


