### PR TITLE
fix missing error handling when creating mutatingwebhookconfiguration

### DIFF
--- a/pkg/webhook/entrypoint.go
+++ b/pkg/webhook/entrypoint.go
@@ -123,6 +123,9 @@ func createMutationConfig(ctx context.Context, kubeClient *kubernetes.Clientset,
 		}
 
 		return err
+	} else if err != nil {
+		logger.Infof(ctx, "Failed to create MutatingWebhookConfiguration [%v/%v]. Error: %v", mutateConfig.GetNamespace(), mutateConfig.GetName(), err)
+		return fmt.Errorf("failed to create mutatingwebhookconfiguration. Error: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: akumor <akumor@users.noreply.github.com>

# TL;DR
This PR adds error handling that makes the flyte-pod-webhook fail correctly when it is unable to create the mutatingwebhookconfiguration instead of silently ignoring the error.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
To ensure that the flyte-pod-webhook fails in an intuitive way, this PR adds a log line and returns an error instead of nil from the function responsible for creating the MutatingWebhookConfiguration.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/2167
