### PR TITLE
Fix: the pod labels in the podTemplate are ignored by the propeller manager

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -86,15 +86,14 @@ func (m *Manager) createPods(ctx context.Context) error {
 		"shardConfigHash":            fmt.Sprintf("%d", shardConfigHash),
 	}
 	podNames := m.getPodNames()
-	podLabels := map[string]string{
-		"app": m.podApplication,
-	}
-	// The "app" label might be overwritten by the pod template
+	podLabels := make(map[string]string)
 	if podTemplate.Template.Labels != nil {
 		for k, v := range podTemplate.Template.Labels {
 			podLabels[k] = v
 		}
 	}
+	// The "app" label from podTemplate might be overwritten by this
+	podLabels["app"] = m.podApplication
 	// disable leader election on all managed pods
 	container, err := utils.GetContainer(&podTemplate.Template.Spec, m.podTemplateContainerName)
 	if err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -89,7 +89,12 @@ func (m *Manager) createPods(ctx context.Context) error {
 	podLabels := map[string]string{
 		"app": m.podApplication,
 	}
-
+	// The "app" label might be overwritten by the pod template
+	if podTemplate.Template.Labels != nil {
+		for k, v := range podTemplate.Template.Labels {
+			podLabels[k] = v
+		}
+	}
 	// disable leader election on all managed pods
 	container, err := utils.GetContainer(&podTemplate.Template.Spec, m.podTemplateContainerName)
 	if err != nil {


### PR DESCRIPTION
# TL;DR
The flytepropeller manager ignores the pod labels in the flytepropeller's podTemplate, resulting in discrepancies in pod labels between pods created by Helm and pods deployed by flyepropeller manager.
Example labels:
Created by Helm:
```
labels:
    app.kubernetes.io/instance: foo-helmchart
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: flytepropeller
    helm.sh/chart: bar
    pod-template-hash: foobar
```
Created by flytepropeller manager:
```
labels:
    app: flytepropeller
```
This PR tries to add labels defined in podTemplate to the manager deployed pods while maintaining backwards compatibility. Example labels after the fix:
Created by flytepropeller manager
```
labels:
    app.kubernetes.io/instance: foo-helmchart
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: flytepropeller
    helm.sh/chart: bar
    pod-template-hash: foobar
    app: flytepropeller
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue

## Follow-up issue
_NA_
