### PR TITLE
Use PodTemplate metadata in managed Pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
+	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/magiconair/properties v1.8.4
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pkg/errors v0.9.1

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -15,6 +15,8 @@ import (
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 
+	"github.com/imdario/mergo"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	v1 "k8s.io/api/core/v1"
@@ -163,15 +165,24 @@ func (m *Manager) createPods(ctx context.Context) error {
 	errs := stderrors.ErrorCollection{}
 	for i, podName := range podNames {
 		if exists := podExists[podName]; !exists {
+			baseObjectMeta := podTemplate.ObjectMeta.DeepCopy()
+			objectMeta := metav1.ObjectMeta{
+				Annotations:     podAnnotations,
+				Name:            podName,
+				Namespace:       m.podNamespace,
+				Labels:          podLabels,
+				OwnerReferences: m.ownerReferences,
+			}
+
+			err = mergo.Merge(baseObjectMeta, objectMeta, mergo.WithOverride, mergo.WithAppendSlice)
+			if err != nil {
+				errs.Append(fmt.Errorf("failed to initialize pod ObjectMeta for '%s' [%v]", podName, err))
+				continue
+			}
+
 			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations:     podAnnotations,
-					Name:            podName,
-					Namespace:       m.podNamespace,
-					Labels:          podLabels,
-					OwnerReferences: m.ownerReferences,
-				},
-				Spec: *podTemplate.Template.Spec.DeepCopy(),
+				ObjectMeta: *baseObjectMeta,
+				Spec:       *podTemplate.Template.Spec.DeepCopy(),
 			}
 
 			err := m.shardStrategy.UpdatePodSpec(&pod.Spec, m.podTemplateContainerName, i)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -165,7 +165,7 @@ func (m *Manager) createPods(ctx context.Context) error {
 	errs := stderrors.ErrorCollection{}
 	for i, podName := range podNames {
 		if exists := podExists[podName]; !exists {
-			baseObjectMeta := podTemplate.ObjectMeta.DeepCopy()
+			baseObjectMeta := podTemplate.Template.ObjectMeta.DeepCopy()
 			objectMeta := metav1.ObjectMeta{
 				Annotations:     podAnnotations,
 				Name:            podName,

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -22,16 +22,18 @@ import (
 var (
 	podTemplate = &v1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"foo": "bar",
-			},
-			Labels: map[string]string{
-				"app": "foo",
-				"bar": "baz",
-			},
 			ResourceVersion: "0",
 		},
 		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"foo": "bar",
+				},
+				Labels: map[string]string{
+					"app": "foo",
+					"bar": "baz",
+				},
+			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					v1.Container{

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -22,6 +22,13 @@ import (
 var (
 	podTemplate = &v1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string {
+				"foo": "bar",
+			},
+			Labels: map[string]string {
+				"app": "foo",
+				"bar": "baz",
+			},
 			ResourceVersion: "0",
 		},
 		Template: v1.PodTemplateSpec{
@@ -83,6 +90,12 @@ func TestCreatePods(t *testing.T) {
 			pods, err = kubePodsClient.List(ctx, metav1.ListOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, tt.shardStrategy.GetPodCount(), len(pods.Items))
+
+			for _, pod := range pods.Items {
+				assert.Equal(t, pod.Annotations["foo"], "bar")
+				assert.Equal(t, pod.Labels["app"], "flytepropeller")
+				assert.Equal(t, pod.Labels["bar"], "baz")
+			}
 
 			// execute again to ensure no new pods are created
 			err = manager.createPods(ctx)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -22,10 +22,10 @@ import (
 var (
 	podTemplate = &v1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string {
+			Annotations: map[string]string{
 				"foo": "bar",
 			},
-			Labels: map[string]string {
+			Labels: map[string]string{
 				"app": "foo",
 				"bar": "baz",
 			},


### PR DESCRIPTION
# TL;DR
Instead of initializing managed pods with a new ObjectMeta this PR resuses the ObjectMeta on the PodTemplate. This means that all managed FlytePropeller pods will adhere as closely to the original PodTemplate as possible, meaning labels, annotations, etc are set correctly.

This approach is proposed as an alternative to https://github.com/flyteorg/flytepropeller/pull/410.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 ^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
