### PR TITLE
Deleting pod finalizers regardless of InjectFinalizer configuration

### DIFF
--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -856,8 +856,8 @@ func TestFinalize(t *testing.T) {
 		tctx := getMockTaskContext(PluginPhaseStarted, PluginPhaseStarted)
 		o := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "abc",
-				Namespace: "xyz",
+				Name:      tctx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(),
+				Namespace: tctx.TaskExecutionMetadata().GetNamespace(),
 			},
 		}
 
@@ -894,8 +894,8 @@ func TestFinalize(t *testing.T) {
 		tctx := getMockTaskContext(PluginPhaseStarted, PluginPhaseStarted)
 		o := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "abc",
-				Namespace: "xyz",
+				Name:      tctx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(),
+				Namespace: tctx.TaskExecutionMetadata().GetNamespace(),
 			},
 		}
 

--- a/pkg/controller/workflowstore/resource_version_caching_test.go
+++ b/pkg/controller/workflowstore/resource_version_caching_test.go
@@ -76,9 +76,7 @@ func TestResourceVersionCaching_Get_NotInCache(t *testing.T) {
 
 func fromHashToByteArray(input [32]byte) []byte {
 	output := make([]byte, 32)
-	for idx, val := range input {
-		output[idx] = val
-	}
+	copy(output, input[:])
 	return output
 }
 


### PR DESCRIPTION
# TL;DR
We remove all finalizers from the Pod whether InjectFinalizer is enabled or not. This ensures that Pods may be deleted once completed, even if the parameter changed during Pod execution.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2262

## Follow-up issue
_NA_
