### PR TITLE
Graceful failure on ExecutionNotFound error

### DIFF
--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -230,9 +230,8 @@ func (p *Propeller) Handle(ctx context.Context, namespace, name string) error {
 
 		// ExecutionNotFound error is returned when flyteadmin is missing the workflow. This is not
 		// a valid state unless we are experiencing a race condition where the workflow has not yet
-		// been inserted into the db. Therefore, we allow retries until the maximum number of
-		// failed attempts is reached.
-		if err != nil && eventsErr.IsNotFound(err) && w.Status.FailedAttempts > uint32(p.cfg.MaxWorkflowRetries) {
+		// been inserted into the db (ie. workflow phase is WorkflowPhaseReady).
+		if err != nil && eventsErr.IsNotFound(err) && w.GetExecutionStatus().GetPhase() != v1alpha1.WorkflowPhaseReady {
 			t.Stop()
 			logger.Errorf(ctx, "Failed to process workflow, failing: %s", err)
 

--- a/pkg/controller/handler_test.go
+++ b/pkg/controller/handler_test.go
@@ -462,8 +462,7 @@ func TestPropeller_Handle(t *testing.T) {
 		assert.Equal(t, 0, len(r.Finalizers))
 		assert.True(t, HasCompletedLabel(r))
 	})
-
-	t.Run("continueOnExecutionNotFoundError", func(t *testing.T) {
+	t.Run("failOnExecutionNotFoundError", func(t *testing.T) {
 		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name,
@@ -478,36 +477,6 @@ func TestPropeller_Handle(t *testing.T) {
 			},
 		}))
 		exec.HandleCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow) error {
-			return workflowErrors.Wrapf(workflowErrors.EventRecordingError, "",
-				&eventErrors.EventError{
-					Code:    eventErrors.ExecutionNotFound,
-					Cause:   nil,
-					Message: "The execution that the event belongs to does not exist",
-				}, "failed to transition phase")
-		}
-		assert.Error(t, p.Handle(ctx, namespace, name))
-
-		r, err := s.Get(ctx, namespace, name)
-		assert.NoError(t, err)
-		assert.Equal(t, v1alpha1.WorkflowPhaseRunning, r.GetExecutionStatus().GetPhase())
-		assert.Equal(t, 0, len(r.Finalizers))
-		assert.False(t, HasCompletedLabel(r))
-	})
-	t.Run("failOnExecutionNotFoundError", func(t *testing.T) {
-		assert.NoError(t, s.Create(ctx, &v1alpha1.FlyteWorkflow{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			WorkflowSpec: &v1alpha1.WorkflowSpec{
-				ID: "w1",
-			},
-			Status: v1alpha1.WorkflowStatus{
-				Phase:          v1alpha1.WorkflowPhaseRunning,
-				FailedAttempts: 1,
-			},
-		}))
-		exec.HandleAbortedCb = func(ctx context.Context, w *v1alpha1.FlyteWorkflow, maxRetries uint32) error {
 			return workflowErrors.Wrapf(workflowErrors.EventRecordingError, "",
 				&eventErrors.EventError{
 					Code:    eventErrors.ExecutionNotFound,

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -1057,7 +1057,7 @@ func (c *nodeExecutor) AbortHandler(ctx context.Context, execContext executors.E
 			},
 			ProducerId: c.clusterID,
 		})
-		if err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
+		if err != nil && !eventsErr.IsNotFound(err) && !eventsErr.IsEventIncompatibleClusterError(err) {
 			if errors2.IsCausedBy(err, errors.IllegalStateError) {
 				logger.Debugf(ctx, "Failed to record abort event due to illegal state transition. Ignoring the error. Error: %v", err)
 			} else {

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -761,7 +761,7 @@ func (t Handler) Abort(ctx context.Context, nCtx handler.NodeExecutionContext, r
 				Code:    "Task Aborted",
 				Message: reason,
 			}},
-	}, t.eventConfig); err != nil && !eventsErr.IsEventIncompatibleClusterError(err) {
+	}, t.eventConfig); err != nil && !eventsErr.IsNotFound(err) && !eventsErr.IsEventIncompatibleClusterError(err) {
 		// If a prior workflow/node/task execution event has failed because of an invalid cluster error, don't stall the abort
 		// at this point in the clean-up.
 		logger.Errorf(ctx, "failed to send event to Admin. error: %s", err.Error())

--- a/pkg/controller/workflow/executor.go
+++ b/pkg/controller/workflow/executor.go
@@ -342,7 +342,7 @@ func (c *workflowExecutor) TransitionToPhase(ctx context.Context, execID *core.W
 				return nil
 			}
 			if (wfEvent.Phase == core.WorkflowExecution_FAILING || wfEvent.Phase == core.WorkflowExecution_FAILED) &&
-				eventsErr.IsEventIncompatibleClusterError(recordingErr) {
+				(eventsErr.IsNotFound(recordingErr) || eventsErr.IsEventIncompatibleClusterError(recordingErr)) {
 				// Don't stall the workflow transition to terminated (so that resources can be cleaned up) since these events
 				// are being discarded by the back-end anyways.
 				logger.Infof(ctx, "Failed to record %s workflowEvent, error [%s]. Ignoring this error!", wfEvent.Phase.String(), recordingErr.Error())


### PR DESCRIPTION
# TL;DR
Updating the workflow abort pipeline to drop ExecutionNotFound errors. Previously, this solution could handle workflows that have not yet started, but for those that are already executing the events that are sent as part of aborting the workflow triggered a cycle.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2275

## Follow-up issue
_NA_
