### PR TITLE
Restrict garbage collection with sharded propeller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -453,8 +453,9 @@ func New(ctx context.Context, cfg *config.Config, kubeclientset kubernetes.Inter
 	return controller, nil
 }
 
-// SharedInformerOptions creates informer options to work with FlytePropeller Sharding
-func SharedInformerOptions(cfg *config.Config, defaultNamespace string) []informers.SharedInformerOption {
+// getShardedLabelSelectorRequirements computes the collection of LabelSelectorReuquirements to
+// satisfy sharding criteria.
+func getShardedLabelSelectorRequirements(cfg *config.Config) []v1.LabelSelectorRequirement {
 	selectors := []struct {
 		label     string
 		operation v1.LabelSelectorOperator
@@ -468,7 +469,7 @@ func SharedInformerOptions(cfg *config.Config, defaultNamespace string) []inform
 		{k8s.DomainLabel, v1.LabelSelectorOpNotIn, cfg.ExcludeDomainLabel},
 	}
 
-	labelSelector := IgnoreCompletedWorkflowsLabelSelector()
+	var labelSelectorRequirements []v1.LabelSelectorRequirement
 	for _, selector := range selectors {
 		if len(selector.values) > 0 {
 			labelSelectorRequirement := v1.LabelSelectorRequirement{
@@ -477,8 +478,20 @@ func SharedInformerOptions(cfg *config.Config, defaultNamespace string) []inform
 				Values:   selector.values,
 			}
 
-			labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, labelSelectorRequirement)
+			labelSelectorRequirements = append(labelSelectorRequirements, labelSelectorRequirement)
 		}
+	}
+
+	return labelSelectorRequirements
+}
+
+// SharedInformerOptions creates informer options to work with FlytePropeller Sharding
+func SharedInformerOptions(cfg *config.Config, defaultNamespace string) []informers.SharedInformerOption {
+	labelSelector := IgnoreCompletedWorkflowsLabelSelector()
+
+	shardedLabelSelectorRequirements := getShardedLabelSelectorRequirements(cfg)
+	if len(shardedLabelSelectorRequirements) != 0 {
+		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, shardedLabelSelectorRequirements...)
 	}
 
 	opts := []informers.SharedInformerOption{

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -28,21 +28,21 @@ type gcMetrics struct {
 // GarbageCollector is an active background cleanup service, that deletes all workflows that are completed and older
 // than the configured TTL
 type GarbageCollector struct {
-	wfClient        v1alpha1.FlyteworkflowV1alpha1Interface
-	namespaceClient corev1.NamespaceInterface
-	ttlHours        int
-	interval        time.Duration
-	clk             clock.Clock
-	metrics         *gcMetrics
-	namespace       string
+	wfClient                   v1alpha1.FlyteworkflowV1alpha1Interface
+	namespaceClient            corev1.NamespaceInterface
+	ttlHours                   int
+	interval                   time.Duration
+	clk                        clock.Clock
+	metrics                    *gcMetrics
+	namespace                  string
+	labelSelectorRequirements  []v1.LabelSelectorRequirement
 }
 
 // Issues a background deletion command with label selector for all completed workflows outside of the retention period
 func (g *GarbageCollector) deleteWorkflows(ctx context.Context) error {
 	s := CompletedWorkflowsSelectorOutsideRetentionPeriod(g.ttlHours, g.clk.Now())
-	shardedLabelSelectorRequirements := getShardedLabelSelectorRequirements(cfg)
-	if len(shardedLabelSelectorRequirements) != 0 {
-		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, shardedLabelSelectorRequirements...)
+	if len(g.labelSelectorRequirements) != 0 {
+		s.MatchExpressions = append(s.MatchExpressions, g.labelSelectorRequirements...)
 	}
 
 	// Delete doesn't support 'all' namespaces. Let's fetch namespaces and loop over each.
@@ -78,6 +78,9 @@ func (g *GarbageCollector) deleteWorkflows(ctx context.Context) error {
 // Deprecated: Please use deleteWorkflows instead
 func (g *GarbageCollector) deprecatedDeleteWorkflows(ctx context.Context) error {
 	s := DeprecatedCompletedWorkflowsSelectorOutsideRetentionPeriod(g.ttlHours, g.clk.Now())
+	if len(g.labelSelectorRequirements) != 0 {
+		s.MatchExpressions = append(s.MatchExpressions, g.labelSelectorRequirements...)
+	}
 
 	// Delete doesn't support 'all' namespaces. Let's fetch namespaces and loop over each.
 	if g.namespace == "" || strings.ToLower(g.namespace) == "all" || strings.ToLower(g.namespace) == "all-namespaces" {
@@ -172,6 +175,7 @@ func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Cl
 	} else {
 		logger.Warningf(context.TODO(), "defaulting max ttl for workflows to 23 hours, since configured duration is larger than 23 [%d]", cfg.MaxTTLInHours)
 	}
+	labelSelectorRequirements := getShardedLabelSelectorRequirements(cfg)
 	return &GarbageCollector{
 		wfClient:        wfClient,
 		ttlHours:        ttl,
@@ -182,7 +186,8 @@ func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Cl
 			gcRoundSuccess: labeled.NewCounter("gc_success", "successful executions of delete request", scope),
 			gcRoundFailure: labeled.NewCounter("gc_failure", "failure to delete workflows", scope),
 		},
-		clk:       clk,
-		namespace: cfg.LimitNamespace,
+		clk:                       clk,
+		namespace:                 cfg.LimitNamespace,
+		labelSelectorRequirements: labelSelectorRequirements,
 	}, nil
 }

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -28,14 +28,14 @@ type gcMetrics struct {
 // GarbageCollector is an active background cleanup service, that deletes all workflows that are completed and older
 // than the configured TTL
 type GarbageCollector struct {
-	wfClient                   v1alpha1.FlyteworkflowV1alpha1Interface
-	namespaceClient            corev1.NamespaceInterface
-	ttlHours                   int
-	interval                   time.Duration
-	clk                        clock.Clock
-	metrics                    *gcMetrics
-	namespace                  string
-	labelSelectorRequirements  []v1.LabelSelectorRequirement
+	wfClient                  v1alpha1.FlyteworkflowV1alpha1Interface
+	namespaceClient           corev1.NamespaceInterface
+	ttlHours                  int
+	interval                  time.Duration
+	clk                       clock.Clock
+	metrics                   *gcMetrics
+	namespace                 string
+	labelSelectorRequirements []v1.LabelSelectorRequirement
 }
 
 // Issues a background deletion command with label selector for all completed workflows outside of the retention period

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -40,6 +40,10 @@ type GarbageCollector struct {
 // Issues a background deletion command with label selector for all completed workflows outside of the retention period
 func (g *GarbageCollector) deleteWorkflows(ctx context.Context) error {
 	s := CompletedWorkflowsSelectorOutsideRetentionPeriod(g.ttlHours, g.clk.Now())
+	shardedLabelSelectorRequirements := getShardedLabelSelectorRequirements(cfg)
+	if len(shardedLabelSelectorRequirements) != 0 {
+		labelSelector.MatchExpressions = append(labelSelector.MatchExpressions, shardedLabelSelectorRequirements...)
+	}
 
 	// Delete doesn't support 'all' namespaces. Let's fetch namespaces and loop over each.
 	if g.namespace == "" || strings.ToLower(g.namespace) == "all" || strings.ToLower(g.namespace) == "all-namespaces" {


### PR DESCRIPTION
# TL;DR
The PR applies the label selectors for sharded propeller to the garbage collector as well as the FlyteWorkflow CRD informer. This means that each individual sharded FlytePropeller instance will only garbage collect for FlyteWorkflows that it is responsible for executing.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2532

## Follow-up issue
_NA_
