### PR TITLE
Make metric keys configurable

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -7,27 +7,28 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/flyteorg/flytepropeller/pkg/controller/executors"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/flyteorg/flytestdlib/profutils"
-	"github.com/flyteorg/flytestdlib/promutils"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/klog"
-
+	"github.com/flyteorg/flytepropeller/pkg/controller"
 	config2 "github.com/flyteorg/flytepropeller/pkg/controller/config"
-
-	"github.com/flyteorg/flytestdlib/config/viper"
-	"github.com/flyteorg/flytestdlib/version"
+	"github.com/flyteorg/flytepropeller/pkg/controller/executors"
+	"github.com/flyteorg/flytepropeller/pkg/signals"
 
 	"github.com/flyteorg/flytestdlib/config"
+	"github.com/flyteorg/flytestdlib/config/viper"
+	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/logger"
-	"github.com/spf13/pflag"
+	"github.com/flyteorg/flytestdlib/profutils"
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/flyteorg/flytestdlib/promutils/labeled"
+	"github.com/flyteorg/flytestdlib/version"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
-	"github.com/flyteorg/flytepropeller/pkg/controller"
-	"github.com/flyteorg/flytepropeller/pkg/signals"
+	"golang.org/x/sync/errgroup"
+
+	"k8s.io/klog"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -107,6 +108,13 @@ func logAndExit(err error) {
 func executeRootCmd(baseCtx context.Context, cfg *config2.Config) error {
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.SetupSignalHandler(baseCtx)
+
+    // set metric keys
+	keys := contextutils.MetricKeysFromStrings(cfg.MetricKeys)
+	logger.Infof(context.TODO(), "setting metrics keys to %+v", keys)
+	if len(keys) > 0 {
+		labeled.SetMetricKeys(keys...)
+	}
 
 	// Add the propeller subscope because the MetricsPrefix only has "flyte:" to get uniform collection of metrics.
 	propellerScope := promutils.NewScope(cfg.MetricsPrefix).NewSubScope("propeller").NewSubScope(cfg.LimitNamespace)

--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -109,7 +109,7 @@ func executeRootCmd(baseCtx context.Context, cfg *config2.Config) error {
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.SetupSignalHandler(baseCtx)
 
-    // set metric keys
+	// set metric keys
 	keys := contextutils.MetricKeysFromStrings(cfg.MetricKeys)
 	logger.Infof(context.TODO(), "setting metrics keys to %+v", keys)
 	if len(keys) > 0 {

--- a/cmd/controller/cmd/webhook.go
+++ b/cmd/controller/cmd/webhook.go
@@ -3,21 +3,24 @@ package cmd
 import (
 	"context"
 
-	"github.com/flyteorg/flytepropeller/pkg/controller/executors"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	"github.com/flyteorg/flytepropeller/pkg/controller"
-	"github.com/flyteorg/flytestdlib/promutils"
-	"golang.org/x/sync/errgroup"
-
-	webhookConfig "github.com/flyteorg/flytepropeller/pkg/webhook/config"
-	"github.com/flyteorg/flytestdlib/profutils"
-
 	"github.com/flyteorg/flytepropeller/pkg/controller/config"
+	"github.com/flyteorg/flytepropeller/pkg/controller/executors"
 	"github.com/flyteorg/flytepropeller/pkg/signals"
 	"github.com/flyteorg/flytepropeller/pkg/webhook"
+	webhookConfig "github.com/flyteorg/flytepropeller/pkg/webhook/config"
+
+	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/logger"
+	"github.com/flyteorg/flytestdlib/profutils"
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/flyteorg/flytestdlib/promutils/labeled"
+
 	"github.com/spf13/cobra"
+
+	"golang.org/x/sync/errgroup"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var webhookCmd = &cobra.Command{
@@ -84,6 +87,13 @@ func init() {
 func runWebhook(origContext context.Context, propellerCfg *config.Config, cfg *webhookConfig.Config) error {
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.SetupSignalHandler(origContext)
+
+    // set metric keys
+	keys := contextutils.MetricKeysFromStrings(propellerCfg.MetricKeys)
+	logger.Infof(context.TODO(), "setting metrics keys to %+v", keys)
+	if len(keys) > 0 {
+		labeled.SetMetricKeys(keys...)
+	}
 
 	webhookScope := promutils.NewScope(cfg.MetricsPrefix).NewSubScope("webhook")
 	limitNamespace := ""

--- a/cmd/controller/cmd/webhook.go
+++ b/cmd/controller/cmd/webhook.go
@@ -88,7 +88,7 @@ func runWebhook(origContext context.Context, propellerCfg *config.Config, cfg *w
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.SetupSignalHandler(origContext)
 
-    // set metric keys
+	// set metric keys
 	keys := contextutils.MetricKeysFromStrings(propellerCfg.MetricKeys)
 	logger.Infof(context.TODO(), "setting metrics keys to %+v", keys)
 	if len(keys) > 0 {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -2,16 +2,9 @@ package main
 
 import (
 	_ "github.com/flyteorg/flytepropeller/plugins"
-	"github.com/flyteorg/flytestdlib/contextutils"
-	"github.com/flyteorg/flytestdlib/promutils/labeled"
 
 	"github.com/flyteorg/flytepropeller/cmd/controller/cmd"
 )
-
-func init() {
-	labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey,
-		contextutils.TaskIDKey)
-}
 
 func main() {
 	cmd.Execute()

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/flyteorg/flytestdlib/config"
+	"github.com/flyteorg/flytestdlib/contextutils"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -105,6 +106,8 @@ var (
 		MetadataPrefix:      "metadata/propeller",
 		EnableAdminLauncher: true,
 		MetricsPrefix:       "flyte",
+		MetricKeys: []string{contextutils.ProjectKey.String(), contextutils.DomainKey.String(),
+			contextutils.WorkflowIDKey.String(), contextutils.TaskIDKey.String()},
 		EventConfig: EventConfig{
 			RawOutputPolicy: RawOutputPolicyReference,
 		},
@@ -128,6 +131,7 @@ type Config struct {
 	DefaultRawOutputPrefix string               `json:"rawoutput-prefix" pflag:",a fully qualified storage path of the form s3://flyte/abc/..., where all data sandboxes should be stored."`
 	Queue                  CompositeQueueConfig `json:"queue,omitempty" pflag:",Workflow workqueue configuration, affects the way the work is consumed from the queue."`
 	MetricsPrefix          string               `json:"metrics-prefix" pflag:",An optional prefix for all published metrics."`
+	MetricKeys             []string             `json:"metrics-keys" pflag:",Metrics labels applied to prometheus metrics emitted by the service."`
 	EnableAdminLauncher    bool                 `json:"enable-admin-launcher" pflag:"Enable remote Workflow launcher to Admin"`
 	MaxWorkflowRetries     int                  `json:"max-workflow-retries" pflag:"Maximum number of retries per workflow"`
 	MaxTTLInHours          int                  `json:"max-ttl-hours" pflag:"Maximum number of hours a completed workflow should be retained. Number between 1-23 hours"`

--- a/pkg/controller/config/config_flags.go
+++ b/pkg/controller/config/config_flags.go
@@ -73,6 +73,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "queue.batching-interval"), defaultConfig.Queue.BatchingInterval.String(), "Duration for which downstream updates are buffered")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "queue.batch-size"), defaultConfig.Queue.BatchSize, "Number of downstream triggered top-level objects to re-enqueue every duration. -1 indicates all available.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "metrics-prefix"), defaultConfig.MetricsPrefix, "An optional prefix for all published metrics.")
+	cmdFlags.StringSlice(fmt.Sprintf("%v%v", prefix, "metrics-keys"), defaultConfig.MetricKeys, "Metrics labels applied to prometheus metrics emitted by the service.")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "enable-admin-launcher"), defaultConfig.EnableAdminLauncher, "")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "max-workflow-retries"), defaultConfig.MaxWorkflowRetries, "")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "max-ttl-hours"), defaultConfig.MaxTTLInHours, "")

--- a/pkg/controller/config/config_flags_test.go
+++ b/pkg/controller/config/config_flags_test.go
@@ -421,6 +421,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_metrics-keys", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := join_Config(defaultConfig.MetricKeys, ",")
+
+			cmdFlags.Set("metrics-keys", testValue)
+			if vStringSlice, err := cmdFlags.GetStringSlice("metrics-keys"); err == nil {
+				testDecodeRaw_Config(t, join_Config(vStringSlice, ","), &actual.MetricKeys)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_enable-admin-launcher", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {


### PR DESCRIPTION
# TL;DR
This PR allows manually configuring prometheus metric labels using metric keys. Currently FlytePropeller default metric keys include the workflow and task IDs. This means that as the number of workflows / tasks increases the cardinality of metrics will increase as well. For some deployments this is undesirable. By enabling manual configuration we can tweak metric cardinality to satisfy deployment requirements.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2565

## Follow-up issue
_NA_