### PR TITLE
Calling abort rather than finalize on permanent failure

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -659,7 +659,7 @@ func (c *nodeExecutor) handleNode(ctx context.Context, dag executors.DAGStructur
 
 	if currentPhase == v1alpha1.NodePhaseFailing {
 		logger.Debugf(ctx, "node failing")
-		if err := c.finalize(ctx, h, nCtx); err != nil {
+		if err := c.abort(ctx, h, nCtx, "node failing"); err != nil {
 			return executors.NodeStatusUndefined, err
 		}
 		nodeStatus.UpdatePhase(v1alpha1.NodePhaseFailed, v1.Now(), nodeStatus.GetMessage(), nodeStatus.GetExecutionError())

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -790,6 +790,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 				} else {
 					h.OnFinalizeMatch(mock.Anything, mock.Anything).Return(nil)
 				}
+				h.OnAbortMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				hf.OnGetHandler(v1alpha1.NodeKindTask).Return(h, nil)
 
 				mockWf, _, mockNodeStatus := createSingleNodeWf(test.currentNodePhase, 0)


### PR DESCRIPTION
# TL;DR
Currently FlytePropeller [calls "finalize"](https://github.com/flyteorg/flytepropeller/blob/b9fb6e31eeb27a15c522995b0c0ea0f5536c0fe0/pkg/controller/nodes/executor.go#L662) rather than "abort" on permanent failures. Consequently, during instances where a resource is actively running we fail to abort it. For example when the number of [timeouts](https://github.com/flyteorg/flytepropeller/blob/b9fb6e31eeb27a15c522995b0c0ea0f5536c0fe0/pkg/controller/nodes/executor.go#L389-L393) exceeds the maximum number of retries we [automatically transition](https://github.com/flyteorg/flytepropeller/blob/b9fb6e31eeb27a15c522995b0c0ea0f5536c0fe0/pkg/controller/nodes/executor.go#L397-L405) from a retryable failure to a permanent failure.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I do not believe there are any unintended side-effects by calling abort. If a node has not yet been executed (ex. dynamic, subworkflow, etc) the abort should still be successful. If this is not the case, we will need to revisit this logic to ensure we fail correctly.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2298

## Follow-up issue
_NA_
