### PR TITLE
Enable leader election on managed instances in a sharded deployment

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/client-go/kubernetes"
@@ -57,6 +58,7 @@ func newManagerMetrics(scope promutils.Scope) *metrics {
 type Manager struct {
 	kubeClient               kubernetes.Interface
 	leaderElector            *leaderelection.LeaderElector
+	leaderNamespacedName     types.NamespacedName
 	metrics                  *metrics
 	ownerReferences          []metav1.OwnerReference
 	podApplication           string
@@ -92,13 +94,13 @@ func (m *Manager) createPods(ctx context.Context) error {
 		"app": m.podApplication,
 	}
 
-	// disable leader election on all managed pods
+	/*// disable leader election on all managed pods
 	container, err := utils.GetContainer(&podTemplate.Template.Spec, m.podTemplateContainerName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve flytepropeller container from pod template [%v]", err)
 	}
 
-	container.Args = append(container.Args, "--propeller.leader-election.enabled=false")
+	container.Args = append(container.Args, "--propeller.leader-election.enabled=false")*/
 
 	// retrieve existing pods
 	listOptions := metav1.ListOptions{
@@ -191,6 +193,17 @@ func (m *Manager) createPods(ctx context.Context) error {
 				continue
 			}
 
+			if len(m.leaderNamespacedName.String()) != 0 {
+				// adopt configured leader election in managed flytepropeller instances
+				container, err := utils.GetContainer(&pod.Spec, m.podTemplateContainerName)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve flytepropeller container from pod template [%v]", err)
+				}
+
+				injectLeaderNameArg := fmt.Sprintf("--propeller.leader-election.lock-config-map.Name=%s-%s", m.leaderNamespacedName.Name, i)
+				container.Args = append(container.Args, injectLeaderNameArg)
+			}
+
 			_, err = m.kubeClient.CoreV1().Pods(m.podNamespace).Create(ctx, pod, metav1.CreateOptions{})
 			if err != nil {
 				errs.Append(fmt.Errorf("failed to create pod '%s' [%v]", podName, err))
@@ -256,6 +269,7 @@ func New(ctx context.Context, propellerCfg *propellerConfig.Config, cfg *manager
 
 	manager := &Manager{
 		kubeClient:               kubeClient,
+		leaderNamespacedName:     propellerCfg.LeaderElection.LockConfigMap,
 		metrics:                  newManagerMetrics(scope),
 		ownerReferences:          ownerReferences,
 		podApplication:           cfg.PodApplication,


### PR DESCRIPTION
# TL;DR
This PR overrides the namespaced name of the leader election configuration for each managed instance. We set this to "propeller-leader-%d" where '%d' is the ID of the managed instance. All other leader election configuration relies on the PodTemplate used for managed instances. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
An alternative approach would be to parse the leader election configuration of the managed instance PodTemplate and append the ID onto that string rather than using the defaulted "propeller-leader" prefix. This approach gets far more complex than is necessary as we would have to parse config map mounts through the pod and into the volume map in the podtemplate container - ensuring we are correctly parsing overrides along the way. If hardcoding the leader election prefix becomes problematic in the future, we will have to take this approach.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2557

## Follow-up issue
_NA_
