### PR TITLE
Add nil check for output reader

### DIFF
--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -484,15 +484,16 @@ func (t Handler) invokePlugin(ctx context.Context, p pluginCore.Plugin, tCtx *ta
 			pluginTrns.ObservedExecutionError(ee)
 		} else {
 			var deckURI *storage.DataReference
-			exists, err := tCtx.ow.GetReader().DeckExists(ctx)
-			if err != nil {
-				logger.Errorf(ctx, "Failed to check deck file existence. Error: %v", err)
-				return pluginTrns, regErrors.Wrapf(err, "failed to check existence of deck file")
-			} else if exists {
-				deckURIValue := tCtx.ow.GetDeckPath()
-				deckURI = &deckURIValue
+			if tCtx.ow.GetReader() != nil {
+				exists, err := tCtx.ow.GetReader().DeckExists(ctx)
+				if err != nil {
+					logger.Errorf(ctx, "Failed to check deck file existence. Error: %v", err)
+					return pluginTrns, regErrors.Wrapf(err, "failed to check existence of deck file")
+				} else if exists {
+					deckURIValue := tCtx.ow.GetDeckPath()
+					deckURI = &deckURIValue
+				}
 			}
-
 			pluginTrns.ObserveSuccess(tCtx.ow.GetOutputPath(), deckURI,
 				&event.TaskNodeMetadata{
 					CacheStatus: cacheStatus.GetCacheStatus(),


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
https://flyte-org.slack.com/archives/CP2HDHKE1/p1659445048597709

`tCtx.ow.GetReader()` is nil when running map task or BigQuery task with no output. so we should add nil check for it.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
