### PR TITLE
Enabled workqueue subqueue additions

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -160,21 +160,20 @@ func (c *Controller) enqueueFlyteWorkflow(obj interface{}) {
 	c.workQueue.AddRateLimited(key.String())
 }
 
-func (c *Controller) enqueueWorkflowForNodeUpdates(wID v1alpha1.WorkflowID) {
-	if wID == "" {
+func (c *Controller) enqueueWorkflowForNodeUpdates(workflowID v1alpha1.WorkflowID) {
+	ctx := context.TODO()
+
+	// validate workflowID
+	_, _, err := cache.SplitMetaNamespaceKey(workflowID)
+	if err != nil {
+		logger.Warnf(ctx, "failed to add incorrectly formatted workflowID '%s' to subqueue", workflowID)
 		return
 	}
-	namespace, name, err := cache.SplitMetaNamespaceKey(wID)
-	if err != nil {
-		if _, err2 := c.workflowStore.Get(context.TODO(), namespace, name); err2 != nil {
-			if workflowstore.IsNotFound(err) {
-				// Workflow is not found in storage, was probably deleted, but one of the sub-objects sent an event
-				return
-			}
-		}
-		c.metrics.EnqueueCountTask.Inc()
-		c.workQueue.AddToSubQueue(wID)
-	}
+
+	// add workflowID to subqueue
+	c.workQueue.AddToSubQueue(workflowID)
+	c.metrics.EnqueueCountTask.Inc()
+	logger.Debugf(ctx, "added workflowID '%s' to subqueue", workflowID)
 }
 
 func (c *Controller) getWorkflowUpdatesHandler() cache.ResourceEventHandler {

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -7,45 +7,43 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/validation"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/cache"
-
-	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/backoff"
-	v1 "k8s.io/api/core/v1"
-
+	"github.com/flyteorg/flyteplugins/go/tasks/errors"
+	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
-	"github.com/flyteorg/flytestdlib/contextutils"
-	stdErrors "github.com/flyteorg/flytestdlib/errors"
-	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/source"
-
-	"github.com/flyteorg/flytestdlib/promutils"
-	"github.com/flyteorg/flytestdlib/promutils/labeled"
-
-	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
-	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	compiler "github.com/flyteorg/flytepropeller/pkg/compiler/transformers/k8s"
+	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/backoff"
+	nodeTaskConfig "github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config"
+
+	stdErrors "github.com/flyteorg/flytestdlib/errors"
+	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/logger"
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/flyteorg/flytestdlib/promutils/labeled"
+
+	"golang.org/x/time/rate"
+
+	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/errors"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 
-	nodeTaskConfig "github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 const finalizer = "flyte/flytek8s"
@@ -533,12 +531,22 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 				if evt.ObjectNew == nil {
 					logger.Warn(context.Background(), "Received an Update event with nil MetaNew.")
 				} else if evt.ObjectOld == nil || evt.ObjectOld.GetResourceVersion() != evt.ObjectNew.GetResourceVersion() {
+					// attempt to enqueue this tasks owner by retrieving the workfowID from the resource labels
 					newCtx := contextutils.WithNamespace(context.Background(), evt.ObjectNew.GetNamespace())
-					logger.Debugf(ctx, "Enqueueing owner for updated object [%v/%v]", evt.ObjectNew.GetNamespace(), evt.ObjectNew.GetName())
-					if err := enqueueOwner(k8stypes.NamespacedName{Name: evt.ObjectNew.GetName(), Namespace: evt.ObjectNew.GetNamespace()}); err != nil {
-						logger.Warnf(context.Background(), "Failed to handle Update event for object [%v]", evt.ObjectNew.GetName())
+
+					workflowID, exists := evt.ObjectNew.GetLabels()[compiler.ExecutionIDLabel]
+					if exists {
+						logger.Debugf(ctx, "Enqueueing owner for updated object [%v/%v]", evt.ObjectNew.GetNamespace(), evt.ObjectNew.GetName())
+						namespacedName := k8stypes.NamespacedName{
+							Name: workflowID,
+							Namespace: evt.ObjectNew.GetNamespace(),
+						}
+
+						if err := enqueueOwner(namespacedName); err != nil {
+							logger.Warnf(context.Background(), "Failed to handle Update event for object [%v]", namespacedName)
+						}
+						updateCount.Inc(newCtx)
 					}
-					updateCount.Inc(newCtx)
 				} else {
 					newCtx := contextutils.WithNamespace(context.Background(), evt.ObjectNew.GetNamespace())
 					droppedUpdateCount.Inc(newCtx)
@@ -552,9 +560,10 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 				genericCount.Inc(ctx)
 			},
 		},
-		// Queue
-		// TODO: a more unique workqueue name
-		workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(),
+		// Queue - configured for high throughput so we very infrequently rate limit node updates
+		workqueue.NewNamedRateLimitingQueue(&workqueue.BucketRateLimiter{
+				Limiter: rate.NewLimiter(rate.Limit(10000), 10000),
+			},
 			entry.ResourceToWatch.GetObjectKind().GroupVersionKind().Kind),
 		// Predicates
 		predicate.Funcs{

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -19,8 +19,8 @@ import (
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/backoff"
 	nodeTaskConfig "github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/config"
 
-	stdErrors "github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/contextutils"
+	stdErrors "github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
@@ -35,9 +35,9 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -538,7 +538,7 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 					if exists {
 						logger.Debugf(ctx, "Enqueueing owner for updated object [%v/%v]", evt.ObjectNew.GetNamespace(), evt.ObjectNew.GetName())
 						namespacedName := k8stypes.NamespacedName{
-							Name: workflowID,
+							Name:      workflowID,
 							Namespace: evt.ObjectNew.GetNamespace(),
 						}
 
@@ -562,9 +562,8 @@ func NewPluginManager(ctx context.Context, iCtx pluginsCore.SetupContext, entry 
 		},
 		// Queue - configured for high throughput so we very infrequently rate limit node updates
 		workqueue.NewNamedRateLimitingQueue(&workqueue.BucketRateLimiter{
-				Limiter: rate.NewLimiter(rate.Limit(10000), 10000),
-			},
-			entry.ResourceToWatch.GetObjectKind().GroupVersionKind().Kind),
+			Limiter: rate.NewLimiter(rate.Limit(10000), 10000),
+		}, entry.ResourceToWatch.GetObjectKind().GroupVersionKind().Kind),
 		// Predicates
 		predicate.Funcs{
 			CreateFunc: func(createEvent event.CreateEvent) bool {


### PR DESCRIPTION
# TL;DR
Currently the subqueue in in the workflow queue is not working. This means that Flyte workflows are not enqueued when we detect changes in node status'. Enabling this will result in significant performance improvements.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
