### PR TITLE
Prefix sub-lp exec id with the parent exec-id

### DIFF
--- a/pkg/apis/flyteworkflow/v1alpha1/iface.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/iface.go
@@ -236,8 +236,8 @@ type MutableDynamicNodeStatus interface {
 	SetExecutionError(executionError *core.ExecutionError)
 }
 
-// Interface for Branch node. All the methods are purely read only except for the GetExecutionStatus.
-// p returns ExecutableBranchNodeStatus, which permits some mutations
+// ExecutableBranchNode is an interface for Branch node. All the methods are purely read only except for the
+// GetExecutionStatus. p returns ExecutableBranchNodeStatus, which permits some mutations
 type ExecutableBranchNode interface {
 	GetIf() ExecutableIfBlock
 	GetElse() *NodeID
@@ -246,6 +246,7 @@ type ExecutableBranchNode interface {
 }
 
 type ExecutableWorkflowNodeStatus interface {
+	Versioned
 	GetWorkflowNodePhase() WorkflowNodePhase
 	GetExecutionError() *core.ExecutionError
 }
@@ -253,12 +254,21 @@ type ExecutableWorkflowNodeStatus interface {
 type MutableWorkflowNodeStatus interface {
 	Mutable
 	ExecutableWorkflowNodeStatus
+	MutableVersioned
 	SetWorkflowNodePhase(phase WorkflowNodePhase)
 	SetExecutionError(executionError *core.ExecutionError)
 }
 
 type Mutable interface {
 	IsDirty() bool
+}
+
+type Versioned interface {
+	GetVersion() uint32
+}
+
+type MutableVersioned interface {
+	SetVersion(version uint32)
 }
 
 type MutableNodeStatus interface {

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -17,6 +17,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type VersionedStruct struct {
+	version uint32
+}
+
+func (in *VersionedStruct) SetVersion(version uint32) {
+	in.version = version
+}
+
+func (in VersionedStruct) GetVersion() uint32 {
+	return in.version
+}
+
 type MutableStruct struct {
 	isDirty bool
 }
@@ -158,6 +170,7 @@ const (
 
 type WorkflowNodeStatus struct {
 	MutableStruct
+	VersionedStruct
 	Phase          WorkflowNodePhase    `json:"phase,omitempty"`
 	ExecutionError *core.ExecutionError `json:"executionError,omitempty"`
 }

--- a/pkg/controller/nodes/handler/state.go
+++ b/pkg/controller/nodes/handler/state.go
@@ -35,8 +35,9 @@ type DynamicNodeState struct {
 }
 
 type WorkflowNodeState struct {
-	Phase v1alpha1.WorkflowNodePhase
-	Error *core.ExecutionError
+	Phase   v1alpha1.WorkflowNodePhase
+	Error   *core.ExecutionError
+	Version uint32
 }
 
 type NodeStateWriter interface {

--- a/pkg/controller/nodes/handler/transition_info.go
+++ b/pkg/controller/nodes/handler/transition_info.go
@@ -39,6 +39,7 @@ type DynamicNodeInfo struct {
 
 type WorkflowNodeInfo struct {
 	LaunchedWorkflowID *core.WorkflowExecutionIdentifier
+	Version            uint32
 }
 
 type BranchNodeInfo struct {

--- a/pkg/controller/nodes/subworkflow/handler.go
+++ b/pkg/controller/nodes/subworkflow/handler.go
@@ -58,7 +58,12 @@ func (w *workflowNodeHandler) Handle(ctx context.Context, nCtx handler.NodeExecu
 			return transition, err
 		}
 
-		workflowNodeState := handler.WorkflowNodeState{Phase: newPhase}
+		version := uint32(0)
+		if info := transition.Info().GetInfo(); info != nil && info.WorkflowNodeInfo != nil {
+			version = info.WorkflowNodeInfo.Version
+		}
+
+		workflowNodeState := handler.WorkflowNodeState{Phase: newPhase, Version: version}
 		err = nCtx.NodeStateWriter().PutWorkflowNodeState(workflowNodeState)
 		if err != nil {
 			logger.Errorf(ctx, "Failed to store WorkflowNodeState, err :%s", err.Error())

--- a/pkg/controller/nodes/subworkflow/launchplan.go
+++ b/pkg/controller/nodes/subworkflow/launchplan.go
@@ -22,6 +22,13 @@ import (
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/subworkflow/launchplan"
 )
 
+type NodeStatusVersion uint32
+
+const (
+	NodeStatusVersion1 NodeStatusVersion = iota
+	NodeStatusVersion2
+)
+
 type launchPlanHandler struct {
 	launchPlan     launchplan.Executor
 	recoveryClient recovery.Client
@@ -56,10 +63,11 @@ func (l *launchPlanHandler) StartLaunchPlan(ctx context.Context, nCtx handler.No
 	if err != nil {
 		return handler.UnknownTransition, err
 	}
-	childID, err := GetChildWorkflowExecutionID(
+	childID, err := GetChildWorkflowExecutionIDV2(
 		parentNodeExecutionID,
 		nCtx.CurrentAttempt(),
 	)
+
 	if err != nil {
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoFailure(core.ExecutionError_SYSTEM, errors.RuntimeExecutionError, "failed to create unique ID", nil)), nil
 	}
@@ -106,8 +114,26 @@ func (l *launchPlanHandler) StartLaunchPlan(ctx context.Context, nCtx handler.No
 	}
 
 	return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRunning(&handler.ExecutionInfo{
-		WorkflowNodeInfo: &handler.WorkflowNodeInfo{LaunchedWorkflowID: childID},
+		WorkflowNodeInfo: &handler.WorkflowNodeInfo{
+			LaunchedWorkflowID: childID,
+			Version:            uint32(NodeStatusVersion2),
+		},
 	})), nil
+}
+
+func GetChildWorkflowExecutionForExecution(parentNodeExecID *core.NodeExecutionIdentifier, nCtx handler.NodeExecutionContext) (*core.WorkflowExecutionIdentifier, error) {
+	// Handle launch plan
+	if nCtx.NodeStateReader().GetWorkflowNodeState().Version == uint32(NodeStatusVersion2) {
+		return GetChildWorkflowExecutionIDV2(
+			parentNodeExecID,
+			nCtx.CurrentAttempt(),
+		)
+	}
+
+	return GetChildWorkflowExecutionID(
+		parentNodeExecID,
+		nCtx.CurrentAttempt(),
+	)
 }
 
 func (l *launchPlanHandler) CheckLaunchPlanStatus(ctx context.Context, nCtx handler.NodeExecutionContext) (handler.Transition, error) {
@@ -115,10 +141,11 @@ func (l *launchPlanHandler) CheckLaunchPlanStatus(ctx context.Context, nCtx hand
 	if err != nil {
 		return handler.UnknownTransition, err
 	}
+
 	// Handle launch plan
-	childID, err := GetChildWorkflowExecutionID(
+	childID, err := GetChildWorkflowExecutionForExecution(
 		parentNodeExecutionID,
-		nCtx.CurrentAttempt(),
+		nCtx,
 	)
 
 	if err != nil {
@@ -203,9 +230,9 @@ func (l *launchPlanHandler) HandleAbort(ctx context.Context, nCtx handler.NodeEx
 	if err != nil {
 		return err
 	}
-	childID, err := GetChildWorkflowExecutionID(
+	childID, err := GetChildWorkflowExecutionForExecution(
 		parentNodeExecutionID,
-		nCtx.CurrentAttempt(),
+		nCtx,
 	)
 	if err != nil {
 		// THIS SHOULD NEVER HAPPEN

--- a/pkg/controller/nodes/subworkflow/util.go
+++ b/pkg/controller/nodes/subworkflow/util.go
@@ -22,3 +22,26 @@ func GetChildWorkflowExecutionID(nodeExecID *core.NodeExecutionIdentifier, attem
 		Name:    name,
 	}, nil
 }
+
+func GetChildWorkflowExecutionIDV2(nodeExecID *core.NodeExecutionIdentifier, attempt uint32) (*core.WorkflowExecutionIdentifier, error) {
+	name, err := encoding.FixedLengthUniqueIDForParts(maxLengthForSubWorkflow, nodeExecID.ExecutionId.Name, nodeExecID.NodeId, strconv.Itoa(int(attempt)))
+	if err != nil {
+		return nil, err
+	}
+
+	// Restriction on name is 20 chars
+	return &core.WorkflowExecutionIdentifier{
+		Project: nodeExecID.ExecutionId.Project,
+		Domain:  nodeExecID.ExecutionId.Domain,
+		Name:    EnsureExecIDWithinLength(nodeExecID.ExecutionId.Name, name, maxLengthForSubWorkflow),
+	}, nil
+}
+
+func EnsureExecIDWithinLength(execID, subName string, maxLength int) string {
+	maxLengthRemaining := maxLength - len(subName)
+	if len(execID) < maxLengthRemaining {
+		return execID + subName
+	}
+
+	return execID[:maxLengthRemaining] + subName
+}

--- a/pkg/controller/nodes/transformers.go
+++ b/pkg/controller/nodes/transformers.go
@@ -252,5 +252,6 @@ func UpdateNodeStatus(np v1alpha1.NodePhase, p handler.PhaseInfo, n *nodeStateMa
 		t := s.GetOrCreateWorkflowStatus()
 		t.SetWorkflowNodePhase(n.w.Phase)
 		t.SetExecutionError(n.w.Error)
+		t.SetVersion(p.GetInfo().WorkflowNodeInfo.Version)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Prefix subnode launchplan with the current execution name to reduce possibility of collisions..
Ensure backward compatibility by storing a version in the workflow node state to be able to generate the same id for check status as we did for launch.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2778