### PR TITLE
Skip the structured dataset format check when the expected format is empty

### DIFF
--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -97,13 +97,12 @@ type schemaTypeChecker struct {
 // Schemas are more complex types in the Flyte ecosystem. A schema is considered castable in the following
 // cases.
 //
-//    1. The downstream schema has no column types specified.  In such a case, it accepts all schema input since it is
-//       generic.
+//  1. The downstream schema has no column types specified.  In such a case, it accepts all schema input since it is
+//     generic.
 //
-//    2. The downstream schema has a subset of the upstream columns and they match perfectly.
+//  2. The downstream schema has a subset of the upstream columns and they match perfectly.
 //
-//    3. The upstream type can be Schema type or structured dataset type
-//
+//  3. The upstream type can be Schema type or structured dataset type
 func (t schemaTypeChecker) CastsFrom(upstreamType *flyte.LiteralType) bool {
 	schemaType := upstreamType.GetSchema()
 	structuredDatasetType := upstreamType.GetStructuredDatasetType()
@@ -130,13 +129,12 @@ type structuredDatasetChecker struct {
 // CastsFrom for Structured dataset are more complex types in the Flyte ecosystem. A structured dataset is considered
 // castable in the following cases:
 //
-//    1. The downstream structured dataset has no column types specified.  In such a case, it accepts all structured dataset input since it is
-//       generic.
+//  1. The downstream structured dataset has no column types specified.  In such a case, it accepts all structured dataset input since it is
+//     generic.
 //
-//    2. The downstream structured dataset has a subset of the upstream structured dataset columns and they match perfectly.
+//  2. The downstream structured dataset has a subset of the upstream structured dataset columns and they match perfectly.
 //
-//    3. The upstream type can be Schema type or structured dataset type
-//
+//  3. The upstream type can be Schema type or structured dataset type
 func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) bool {
 	// structured datasets are nullable
 	if isNoneType(upstreamType) {

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -152,10 +152,6 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 		}
 		return structuredDatasetCastFromSchema(schemaType, t.literalType.GetStructuredDatasetType())
 	}
-	// Skip the format check here when format is empty. https://github.com/flyteorg/flyte/issues/2864
-	if len(structuredDatasetType.Format) != 0 && len(t.literalType.GetStructuredDatasetType().Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
-		return false
-	}
 	return structuredDatasetCastFromStructuredDataset(structuredDatasetType, t.literalType.GetStructuredDatasetType())
 }
 
@@ -225,6 +221,11 @@ func (t unionTypeChecker) CastsFrom(upstreamType *flyte.LiteralType) bool {
 
 // Upstream (structuredDatasetType) -> downstream (structuredDatasetType)
 func structuredDatasetCastFromStructuredDataset(upstream *flyte.StructuredDatasetType, downstream *flyte.StructuredDatasetType) bool {
+	// Skip the format check here when format is empty. https://github.com/flyteorg/flyte/issues/2864
+	if len(upstream.Format) != 0 && len(downstream.Format) != 0 && !strings.EqualFold(upstream.Format, downstream.Format) {
+		return false
+	}
+
 	if len(upstream.Columns) == 0 || len(downstream.Columns) == 0 {
 		return true
 	}

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -153,7 +153,7 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 		return structuredDatasetCastFromSchema(schemaType, t.literalType.GetStructuredDatasetType())
 	}
 	// The expected format (t.literalType.GetStructuredDatasetType().Format) could be empty. e.g. def t1() -> structuredDataset:
-	// Therefore, Ignore the format check here when expected format is empty
+	// Therefore, Skip the format check here when expected format is empty
 	if len(t.literalType.GetStructuredDatasetType().Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
 		return false
 	}

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -152,8 +152,8 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 		}
 		return structuredDatasetCastFromSchema(schemaType, t.literalType.GetStructuredDatasetType())
 	}
-	// When running the BigQuery task, the input format is empty, but the expected type is Parquet.
-	// So Ignore the format check here
+	// The expected format (t.literalType.GetStructuredDatasetType().Format) could be empty. e.g. def t1() -> structuredDataset:
+	// Therefore, Ignore the format check here when expected format is empty
 	if len(t.literalType.GetStructuredDatasetType().Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
 		return false
 	}

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -154,7 +154,7 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 	}
 	// When running the BigQuery task, the input format is empty, but the expected type is Parquet.
 	// So Ignore the format check here
-	if len(structuredDatasetType.Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
+	if len(t.literalType.GetStructuredDatasetType().Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
 		return false
 	}
 	return structuredDatasetCastFromStructuredDataset(structuredDatasetType, t.literalType.GetStructuredDatasetType())

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -152,6 +152,8 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 		}
 		return structuredDatasetCastFromSchema(schemaType, t.literalType.GetStructuredDatasetType())
 	}
+	// When running the BigQuery task, the input format is empty, but the expected type is Parquet.
+	// So Ignore the format check here
 	if len(structuredDatasetType.Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
 		return false
 	}

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -152,9 +152,8 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 		}
 		return structuredDatasetCastFromSchema(schemaType, t.literalType.GetStructuredDatasetType())
 	}
-	// The expected format (t.literalType.GetStructuredDatasetType().Format) could be empty. e.g. def t1() -> structuredDataset:
-	// Therefore, Skip the format check here when expected format is empty
-	if len(t.literalType.GetStructuredDatasetType().Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
+	// Skip the format check here when format is empty. https://github.com/flyteorg/flyte/issues/2864
+	if len(structuredDatasetType.Format) != 0 && len(t.literalType.GetStructuredDatasetType().Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
 		return false
 	}
 	return structuredDatasetCastFromStructuredDataset(structuredDatasetType, t.literalType.GetStructuredDatasetType())

--- a/pkg/compiler/validators/typing.go
+++ b/pkg/compiler/validators/typing.go
@@ -154,7 +154,7 @@ func (t structuredDatasetChecker) CastsFrom(upstreamType *flyte.LiteralType) boo
 		}
 		return structuredDatasetCastFromSchema(schemaType, t.literalType.GetStructuredDatasetType())
 	}
-	if !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
+	if len(structuredDatasetType.Format) != 0 && !strings.EqualFold(structuredDatasetType.Format, t.literalType.GetStructuredDatasetType().Format) {
 		return false
 	}
 	return structuredDatasetCastFromStructuredDataset(structuredDatasetType, t.literalType.GetStructuredDatasetType())

--- a/pkg/compiler/validators/typing_test.go
+++ b/pkg/compiler/validators/typing_test.go
@@ -690,6 +690,14 @@ func TestSchemaCasting(t *testing.T) {
 }
 
 func TestStructuredDatasetCasting(t *testing.T) {
+	emptyStructuredDataset := &core.LiteralType{
+		Type: &core.LiteralType_StructuredDatasetType{
+			StructuredDatasetType: &core.StructuredDatasetType{
+				Columns: []*core.StructuredDatasetType_DatasetColumn{},
+				Format:  "",
+			},
+		},
+	}
 	genericStructuredDataset := &core.LiteralType{
 		Type: &core.LiteralType_StructuredDatasetType{
 			StructuredDatasetType: &core.StructuredDatasetType{
@@ -817,6 +825,11 @@ func TestStructuredDatasetCasting(t *testing.T) {
 	t.Run("MismatchedColumnsFlipped", func(t *testing.T) {
 		castable := AreTypesCastable(mismatchedSubsetStructuredDataset, subsetStructuredDataset)
 		assert.False(t, castable, "StructuredDataset(a=Float) should not be castable to StructuredDataset(a=Integer, b=Collection)")
+	})
+
+	t.Run("EmptyFormatToGeneric", func(t *testing.T) {
+		castable := AreTypesCastable(emptyStructuredDataset, genericStructuredDataset)
+		assert.True(t, castable, "StructuredDataset() should be castable to StructuredDataset(format='Parquet')")
 	})
 
 	t.Run("StructuredDatasetsAreNullable", func(t *testing.T) {

--- a/pkg/compiler/validators/typing_test.go
+++ b/pkg/compiler/validators/typing_test.go
@@ -828,8 +828,8 @@ func TestStructuredDatasetCasting(t *testing.T) {
 	})
 
 	t.Run("EmptyFormatToGeneric", func(t *testing.T) {
-		castable := AreTypesCastable(emptyStructuredDataset, genericStructuredDataset)
-		assert.True(t, castable, "StructuredDataset() should be castable to StructuredDataset(format='Parquet')")
+		castable := AreTypesCastable(genericStructuredDataset, emptyStructuredDataset)
+		assert.True(t, castable, "StructuredDataset(format='Parquet') should be castable to StructuredDataset()")
 	})
 
 	t.Run("StructuredDatasetsAreNullable", func(t *testing.T) {

--- a/pkg/compiler/validators/typing_test.go
+++ b/pkg/compiler/validators/typing_test.go
@@ -827,9 +827,14 @@ func TestStructuredDatasetCasting(t *testing.T) {
 		assert.False(t, castable, "StructuredDataset(a=Float) should not be castable to StructuredDataset(a=Integer, b=Collection)")
 	})
 
-	t.Run("EmptyFormatToGeneric", func(t *testing.T) {
+	t.Run("GenericToEmptyFormat", func(t *testing.T) {
 		castable := AreTypesCastable(genericStructuredDataset, emptyStructuredDataset)
 		assert.True(t, castable, "StructuredDataset(format='Parquet') should be castable to StructuredDataset()")
+	})
+
+	t.Run("EmptyFormatToGeneric", func(t *testing.T) {
+		castable := AreTypesCastable(genericStructuredDataset, emptyStructuredDataset)
+		assert.True(t, castable, "StructuredDataset() should be castable to StructuredDataset(format='Parquet')")
 	})
 
 	t.Run("StructuredDatasetsAreNullable", func(t *testing.T) {


### PR DESCRIPTION
# TL;DR
For more detail, check https://github.com/flyteorg/flyte/issues/2864

Failed to run BQ task when the cache is enabled because [type validation](https://github.com/flyteorg/flytepropeller/blob/9cf5368793e5d60113cb819a6e496a7b6accd619/pkg/compiler/validators/typing.go#L157) is failing.

In some cases, the expected type is empty but the input type has value, so skip the format check when the expected format is empty

When the expected format of SD is empty, the dataframe will be converted to a specific format determined by the SD transformer.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
^^^

## Follow-up issue
_NA_
