### PR TITLE
fix: Add servicename in certs

### DIFF
--- a/pkg/webhook/init_cert.go
+++ b/pkg/webhook/init_cert.go
@@ -48,7 +48,7 @@ func InitCerts(ctx context.Context, propellerCfg *config.Config, cfg *webhookCon
 	}
 
 	logger.Infof(ctx, "Issuing certs")
-	certs, err := createCerts(podNamespace)
+	certs, err := createCerts(cfg.ServiceName, podNamespace)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func createWebhookSecret(ctx context.Context, namespace string, cfg *webhookConf
 	return err
 }
 
-func createCerts(serviceNamespace string) (certs webhookCerts, err error) {
+func createCerts(serviceName string, serviceNamespace string) (certs webhookCerts, err error) {
 	// CA config
 	caRequest := &x509.Certificate{
 		SerialNumber: big.NewInt(2021),
@@ -190,9 +190,9 @@ func createCerts(serviceNamespace string) (certs webhookCerts, err error) {
 		return webhookCerts{}, err
 	}
 
-	dnsNames := []string{"flyte-pod-webhook",
-		"flyte-pod-webhook." + serviceNamespace, "flyte-pod-webhook." + serviceNamespace + ".svc"}
-	commonName := "flyte-pod-webhook." + serviceNamespace + ".svc"
+	dnsNames := []string{serviceName,
+		serviceName + "." + serviceNamespace, serviceName + "." + serviceNamespace + ".svc"}
+	commonName := serviceName + "." + serviceNamespace + ".svc"
 
 	// server cert config
 	certRequest := &x509.Certificate{


### PR DESCRIPTION
The value for the secret namespace for settings is grabbed dynamically.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Before:
A hardcoded string was used for setting the secret namespace

After:
The value for the secret namespace for settings is grabbed dynamically.

Signed-off-by: Francisco J. Solis <siscomagma@gmail.com>

fixes [https://github.com/flyteorg/flyte/issues/<number>
](https://github.com/flyteorg/flyte/issues/2968)
