### PR TITLE
disable k8s controller-runtime manager metrics server

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -131,6 +131,7 @@ func executeRootCmd(baseCtx context.Context, cfg *config2.Config) error {
 		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 			return executors.NewFallbackClientBuilder(propellerScope.NewSubScope("kube")).Build(cache, config, options)
 		},
+		MetricsBindAddress: "0",
 	}
 
 	mgr, err := controller.CreateControllerManager(ctx, cfg, options)

--- a/cmd/controller/cmd/webhook.go
+++ b/cmd/controller/cmd/webhook.go
@@ -110,8 +110,9 @@ func runWebhook(origContext context.Context, propellerCfg *config.Config, cfg *w
 		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 			return executors.NewFallbackClientBuilder(webhookScope).Build(cache, config, options)
 		},
-		CertDir: cfg.CertDir,
-		Port:    cfg.ListenPort,
+		CertDir:            cfg.CertDir,
+		Port:               cfg.ListenPort,
+		MetricsBindAddress: "0",
 	}
 
 	mgr, err := controller.CreateControllerManager(ctx, propellerCfg, options)


### PR DESCRIPTION
# TL;DR
In networking setups where k8s requires Pods serving webhooks to have `hostNetwork: true` deployments may suffer "unable to bind address :8080" in the flyte-pod-webhook deployment. This is because both flytepropeller and the pod-webhook pods use the k8s controller-runtime manager internally to manager k8s informers, caches, etc. A component of the controller-runtime manager is the metrics server, which serves prometheus metrics. In the above scenario, if the flytepropeller and pod-webhook pods are deployed on the same host there will be collisions. This PR disables the controller-runtime manager metrics server.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2974

## Follow-up issue
https://github.com/flyteorg/flyte/issues/2975 - we should serve the k8s controller-runtime manager metrics using FlytePropellers existing prometheus endpoint by using a separate registry.
