### PR TITLE
Set default value for the input of FlyteTask

### DIFF
--- a/pkg/compiler/transformers/k8s/workflow.go
+++ b/pkg/compiler/transformers/k8s/workflow.go
@@ -178,6 +178,8 @@ func BuildFlyteWorkflow(wfClosure *core.CompiledWorkflowClosure, inputs *core.Li
 	} else if requiresInputs(wf) {
 		errs.Collect(errors.NewValueRequiredErr("root", "inputs"))
 		return nil, errs
+	} else {
+		inputs = &core.LiteralMap{}
 	}
 
 	for _, t := range tasks {

--- a/pkg/compiler/transformers/k8s/workflow_test.go
+++ b/pkg/compiler/transformers/k8s/workflow_test.go
@@ -117,6 +117,7 @@ func TestBuildFlyteWorkflow(t *testing.T) {
 	assert.Nil(t, wf.WorkflowSpec.Nodes[common.StartNodeID].Interruptible)
 	assert.Equal(t, "wf-1", wf.Labels[WorkflowNameLabel])
 	assert.Equal(t, "4", wf.Labels[ShardKeyLabel])
+	assert.NotNil(t, wf.Inputs)
 	assert.NoError(t, err)
 	assert.NotNil(t, wf)
 	errors.SetConfig(errors.Config{})


### PR DESCRIPTION
# TL;DR

Failed to execute the FlyteTask because flyteadmin failed to marshal the data. Setting the default input to `core.LiteralMap{}` instead of nil can fix it.
```
    return _end_unary_response_blocking(state, call, False, None)
  File "/tmp/tmp.9GlVfLRofO/venv/lib/python3.10/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INTERNAL
        details = "failed to create workflow in propeller json: error calling MarshalJSON for type *v1alpha1.Inputs: Marshal called with nil"
        debug_error_string = "{"created":"@1666336057.217907913","description":"Error received from peer ipv4:127.0.0.1:30081","file":"src/core/lib/surface/call.cc","file_line":1074,"grpc_message":"failed to create workflow in propeller json: error calling MarshalJSON for type *v1alpha1.Inputs: Marshal called with nil","grpc_status":13}"
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3008

## Follow-up issue
_NA_