### PR TITLE
Check deck uri exists before checking for datastore existance

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -264,14 +264,16 @@ func (c *nodeExecutor) attemptRecovery(ctx context.Context, nCtx handler.NodeExe
 	}
 
 	deckFile := storage.DataReference(recovered.Closure.GetDeckUri())
-	metadata, err := nCtx.DataStore().Head(ctx, deckFile)
-	if err != nil {
-		logger.Errorf(ctx, "Failed to check the existence of deck file. Error: %v", err)
-		return handler.PhaseInfoUndefined, errors.Wrapf(errors.CausedByError, nCtx.NodeID(), err, "Failed to check the existence of deck file.")
-	}
+	if len(deckFile) > 0 {
+		metadata, err := nCtx.DataStore().Head(ctx, deckFile)
+		if err != nil {
+			logger.Errorf(ctx, "Failed to check the existence of deck file. Error: %v", err)
+			return handler.PhaseInfoUndefined, errors.Wrapf(errors.CausedByError, nCtx.NodeID(), err, "Failed to check the existence of deck file.")
+		}
 
-	if metadata.Exists() {
-		oi.DeckURI = &deckFile
+		if metadata.Exists() {
+			oi.DeckURI = &deckFile
+		}
 	}
 
 	if err := c.store.WriteProtobuf(ctx, outputFile, so, outputs); err != nil {


### PR DESCRIPTION
# TL;DR
Check that the DeckURI is not empty (ie. "") before querying the DataStore for file existence. This mitigate issues when querying for an empty file.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3114

## Follow-up issue
https://github.com/flyteorg/flyteconsole/issues/642
