### PR TITLE
Fixed nil panic on gate node sleep check

### DIFF
--- a/pkg/controller/nodes/gate/handler.go
+++ b/pkg/controller/nodes/gate/handler.go
@@ -186,7 +186,7 @@ func (g *gateNodeHandler) Handle(ctx context.Context, nCtx handler.NodeExecution
 
 		// check duration of node sleep
 		lastAttemptStartedAt := nCtx.NodeStatus().GetLastAttemptStartedAt()
-		if lastAttemptStartedAt != nil && sleepDuration <= time.Now().Sub(lastAttemptStartedAt.Time) {
+		if lastAttemptStartedAt != nil && sleepDuration <= time.Since(lastAttemptStartedAt.Time) {
 			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoSuccess(&handler.ExecutionInfo{})), nil
 		}
 	default:

--- a/pkg/controller/nodes/gate/handler.go
+++ b/pkg/controller/nodes/gate/handler.go
@@ -185,8 +185,8 @@ func (g *gateNodeHandler) Handle(ctx context.Context, nCtx handler.NodeExecution
 		sleepDuration := sleepCondition.GetDuration().AsDuration()
 
 		// check duration of node sleep
-		now := time.Now()
-		if sleepDuration <= now.Sub(nCtx.NodeStatus().GetLastAttemptStartedAt().Time) {
+		lastAttemptStartedAt := nCtx.NodeStatus().GetLastAttemptStartedAt()
+		if lastAttemptStartedAt != nil && sleepDuration <= time.Now().Sub(lastAttemptStartedAt.Time) {
 			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoSuccess(&handler.ExecutionInfo{})), nil
 		}
 	default:


### PR DESCRIPTION
# TL;DR
The `LastAttemptStartedAt` is only populated on the `NodeStatus` during transition from `Queued` to `Running` phases. So the first time the GateNode handler evaluates the node it will be nil. This causes a panic when validating the sleep duration. This PR ensures this value is not nil when checking the sleep duration.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
