### PR TITLE
Fix issue where k8s plugin default labels override those set on pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -146,3 +146,5 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteplugins => github.com/flyteorg/flyteplugins v1.0.26-0.20221227162039-2bba1ef34839

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.13.0
 	github.com/flyteorg/flyteidl v1.3.1
-	github.com/flyteorg/flyteplugins v1.0.24
+	github.com/flyteorg/flyteplugins v1.0.26
 	github.com/flyteorg/flytestdlib v1.0.11
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible
@@ -146,5 +146,3 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
-
-replace github.com/flyteorg/flyteplugins => github.com/flyteorg/flyteplugins v1.0.26-0.20221227162039-2bba1ef34839

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.3.1 h1:KIE7hXRmhBHttpyvfWo6X2LYLtx66Oj/nbKMG2V5bs0=
 github.com/flyteorg/flyteidl v1.3.1/go.mod h1:OJAq333OpInPnMhvVz93AlEjmlQ+t0FAD4aakIYE4OU=
-github.com/flyteorg/flyteplugins v1.0.24 h1:tmKyXugKA3qR3zpw1jx90EwulifnL8Q1DyK/jlOquCo=
-github.com/flyteorg/flyteplugins v1.0.24/go.mod h1:x+e4ongzLdwdq7Gpl7TsPxwh1yal2ndWmB9ZqcjUuz8=
+github.com/flyteorg/flyteplugins v1.0.26-0.20221227162039-2bba1ef34839 h1:lNw2tJD7qLS5n+IsCsHlOa34BFbjgiZHFL/ad9Txy2s=
+github.com/flyteorg/flyteplugins v1.0.26-0.20221227162039-2bba1ef34839/go.mod h1:x+e4ongzLdwdq7Gpl7TsPxwh1yal2ndWmB9ZqcjUuz8=
 github.com/flyteorg/flytestdlib v1.0.0/go.mod h1:QSVN5wIM1lM9d60eAEbX7NwweQXW96t5x4jbyftn89c=
 github.com/flyteorg/flytestdlib v1.0.11 h1:f7B8x2/zMuimEVi4Jx0zqzvNhdi7aq7+ZWoqHsbp4F4=
 github.com/flyteorg/flytestdlib v1.0.11/go.mod h1:nIBmBHtjTJvhZEn3e/EwVC/iMkR2tUX8hEiXjRBpH/s=

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.3.1 h1:KIE7hXRmhBHttpyvfWo6X2LYLtx66Oj/nbKMG2V5bs0=
 github.com/flyteorg/flyteidl v1.3.1/go.mod h1:OJAq333OpInPnMhvVz93AlEjmlQ+t0FAD4aakIYE4OU=
-github.com/flyteorg/flyteplugins v1.0.26-0.20221227162039-2bba1ef34839 h1:lNw2tJD7qLS5n+IsCsHlOa34BFbjgiZHFL/ad9Txy2s=
-github.com/flyteorg/flyteplugins v1.0.26-0.20221227162039-2bba1ef34839/go.mod h1:x+e4ongzLdwdq7Gpl7TsPxwh1yal2ndWmB9ZqcjUuz8=
+github.com/flyteorg/flyteplugins v1.0.26 h1:bs1+N+FbEb7ZFs7df7eGrS0fOjDPFrg+ynSrY8nwetM=
+github.com/flyteorg/flyteplugins v1.0.26/go.mod h1:x+e4ongzLdwdq7Gpl7TsPxwh1yal2ndWmB9ZqcjUuz8=
 github.com/flyteorg/flytestdlib v1.0.0/go.mod h1:QSVN5wIM1lM9d60eAEbX7NwweQXW96t5x4jbyftn89c=
 github.com/flyteorg/flytestdlib v1.0.11 h1:f7B8x2/zMuimEVi4Jx0zqzvNhdi7aq7+ZWoqHsbp4F4=
 github.com/flyteorg/flytestdlib v1.0.11/go.mod h1:nIBmBHtjTJvhZEn3e/EwVC/iMkR2tUX8hEiXjRBpH/s=

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -104,7 +104,7 @@ type PluginManager struct {
 func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetadata, o client.Object, cfg *config.K8sPluginConfig) {
 	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
-	o.SetLabels(utils.UnionMaps(o.GetLabels(), utils.CopyMap(taskCtx.GetLabels()), cfg.DefaultLabels))
+	o.SetLabels(utils.UnionMaps(cfg.DefaultLabels, o.GetLabels(), utils.CopyMap(taskCtx.GetLabels())))
 	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())
 
 	if !e.plugin.GetProperties().DisableInjectOwnerReferences {


### PR DESCRIPTION
# TL;DR
Currently the k8s plugin default labels will override those manually set. This PR updates the k8s plugin manager to prefer labels set on the Pod definition over those specified on the defaults k8s plugin configuration.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
