### PR TITLE
Fix gate node approve condition node interface binding validation 

### DIFF
--- a/pkg/compiler/validators/bindings.go
+++ b/pkg/compiler/validators/bindings.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"reflect"
+	"fmt"
 
 	"github.com/flyteorg/flytepropeller/pkg/compiler/typing"
 
@@ -179,13 +180,19 @@ func validateBinding(w c.WorkflowBuilder, nodeID c.NodeID, nodeParam string, bin
 func ValidateBindings(w c.WorkflowBuilder, node c.Node, bindings []*flyte.Binding, params *flyte.VariableMap,
 	validateParamTypes bool, edgeDirection c.EdgeDirection, errs errors.CompileErrors) (resolved *flyte.VariableMap, ok bool) {
 
+	fmt.Printf("HAMERSAW - BINDING FOR NODE %s\n", node.GetId())
+
 	resolved = &flyte.VariableMap{
 		Variables: make(map[string]*flyte.Variable, len(bindings)),
 	}
 
+	fmt.Printf("HAMERSAW - params %s (variables): %+v\n", node.GetId(), params.Variables)
+
 	providedBindings := sets.NewString()
 	for _, binding := range bindings {
+		fmt.Printf("HAMERSAW - binding: %s %+v\n", node.GetId(), binding)
 		if param, ok := findVariableByName(params, binding.GetVar()); !ok && validateParamTypes {
+			fmt.Printf("HAMERSAW - node %s param %+v\n", node.GetId(), param)
 			errs.Collect(errors.NewVariableNameNotFoundErr(node.GetId(), node.GetId(), binding.GetVar()))
 		} else if binding.GetBinding() == nil {
 			errs.Collect(errors.NewValueRequiredErr(node.GetId(), "Binding"))

--- a/pkg/compiler/validators/bindings.go
+++ b/pkg/compiler/validators/bindings.go
@@ -2,7 +2,6 @@ package validators
 
 import (
 	"reflect"
-	"fmt"
 
 	"github.com/flyteorg/flytepropeller/pkg/compiler/typing"
 
@@ -180,19 +179,13 @@ func validateBinding(w c.WorkflowBuilder, nodeID c.NodeID, nodeParam string, bin
 func ValidateBindings(w c.WorkflowBuilder, node c.Node, bindings []*flyte.Binding, params *flyte.VariableMap,
 	validateParamTypes bool, edgeDirection c.EdgeDirection, errs errors.CompileErrors) (resolved *flyte.VariableMap, ok bool) {
 
-	fmt.Printf("HAMERSAW - BINDING FOR NODE %s\n", node.GetId())
-
 	resolved = &flyte.VariableMap{
 		Variables: make(map[string]*flyte.Variable, len(bindings)),
 	}
 
-	fmt.Printf("HAMERSAW - params %s (variables): %+v\n", node.GetId(), params.Variables)
-
 	providedBindings := sets.NewString()
 	for _, binding := range bindings {
-		fmt.Printf("HAMERSAW - binding: %s %+v\n", node.GetId(), binding)
 		if param, ok := findVariableByName(params, binding.GetVar()); !ok && validateParamTypes {
-			fmt.Printf("HAMERSAW - node %s param %+v\n", node.GetId(), param)
 			errs.Collect(errors.NewVariableNameNotFoundErr(node.GetId(), node.GetId(), binding.GetVar()))
 		} else if binding.GetBinding() == nil {
 			errs.Collect(errors.NewValueRequiredErr(node.GetId(), "Binding"))

--- a/pkg/compiler/validators/interface.go
+++ b/pkg/compiler/validators/interface.go
@@ -121,7 +121,8 @@ func ValidateUnderlyingInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs e
 	case *core.Node_GateNode:
 		gateNode := node.GetGateNode()
 		if approve := gateNode.GetApprove(); approve != nil {
-			iface = &core.TypedInterface{
+			fmt.Printf("HAMERSAW - %+v\n", node.GetInputs())
+			iface = &core.TypedInterface{ // TODO @hamersaw - fix this interface
 				Inputs:  &core.VariableMap{Variables: map[string]*core.Variable{}},
 				Outputs: &core.VariableMap{Variables: map[string]*core.Variable{}},
 			}

--- a/pkg/compiler/validators/interface.go
+++ b/pkg/compiler/validators/interface.go
@@ -121,10 +121,14 @@ func ValidateUnderlyingInterface(w c.WorkflowBuilder, node c.NodeBuilder, errs e
 	case *core.Node_GateNode:
 		gateNode := node.GetGateNode()
 		if approve := gateNode.GetApprove(); approve != nil {
-			fmt.Printf("HAMERSAW - %+v\n", node.GetInputs())
-			iface = &core.TypedInterface{ // TODO @hamersaw - fix this interface
-				Inputs:  &core.VariableMap{Variables: map[string]*core.Variable{}},
-				Outputs: &core.VariableMap{Variables: map[string]*core.Variable{}},
+			// discover inputs / outputs from upstream bindings. output variable are identical to inputs
+			// because evaluating the approve condition copies the input LiteralMap directly to outputs.
+			inputVarsFromBindings, _ := ValidateBindings(w, node, node.GetInputs(), &core.VariableMap{Variables: map[string]*core.Variable{}},
+				false, c.EdgeDirectionUpstream, errs.NewScope())
+
+			iface = &core.TypedInterface{
+				Inputs:  inputVarsFromBindings,
+				Outputs: inputVarsFromBindings,
 			}
 		} else if signal := gateNode.GetSignal(); signal != nil {
 			if signal.GetType() == nil {

--- a/pkg/compiler/validators/interface_test.go
+++ b/pkg/compiler/validators/interface_test.go
@@ -301,6 +301,7 @@ func TestValidateUnderlyingInterface(t *testing.T) {
 				},
 			})
 			nodeBuilder.OnGetInterface().Return(nil)
+			nodeBuilder.OnGetInputs().Return(nil)
 
 			nodeBuilder.On("GetGateNode").Return(gateNode)
 			nodeBuilder.On("GetId").Return("node_1")


### PR DESCRIPTION
# TL;DR
Currently, the `ApproveCondition` uses an empty node interface for validating variable bindings. This is incorrect, and results in a compilation failure. This PR uses upstream node bindings to discover the interface for the gate node in the case of an `ApproveCondition`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/208

## Follow-up issue
_NA_
