### PR TITLE
Add TensorFlow to loader.go

### DIFF
--- a/plugins/loader.go
+++ b/plugins/loader.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/dask"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch"
+        _ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/pod"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/ray"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/sagemaker"

--- a/plugins/loader.go
+++ b/plugins/loader.go
@@ -9,7 +9,7 @@ import (
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/dask"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch"
-        _ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow"
+	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/pod"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/ray"
 	_ "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/sagemaker"


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@gmail.com>

# TL;DR
Add `TensorFlow` to loader.go, so we can load `TensorFlow` plugin while starting the propeller.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://flyte-org.slack.com/archives/C045P7GBGBU/p1673314641468229

## Follow-up issue
_NA_
