### PR TITLE
fix recovery of already recovered workflow

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -190,6 +190,8 @@ func (c *nodeExecutor) attemptRecovery(ctx context.Context, nCtx handler.NodeExe
 	case core.NodeExecution_SKIPPED:
 		return handler.PhaseInfoSkip(nil, "node execution recovery indicated original node was skipped"), nil
 	case core.NodeExecution_SUCCEEDED:
+		fallthrough
+	case core.NodeExecution_RECOVERED:
 		logger.Debugf(ctx, "Node [%+v] can be recovered. Proceeding to copy inputs and outputs", nCtx.NodeExecutionMetadata().GetNodeExecutionID())
 	default:
 		// The node execution may be partially recoverable through intra task checkpointing. Save the checkpoint


### PR DESCRIPTION
# TL;DR
If an already recovered workflow was recovered again, all tasks were re-run.
This marks not only successful but also already recovered tasks as recoverable for futher runs.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

See slack discussion: https://flyte-org.slack.com/archives/CP2HDHKE1/p1677245731470789

## Tracking Issue
_NA_

## Follow-up issue
_NA_

