### PR TITLE
Use group attribute for KV version and add DB engine support

### DIFF
--- a/pkg/webhook/config/config.go
+++ b/pkg/webhook/config/config.go
@@ -114,7 +114,7 @@ type GCPSecretManagerConfig struct {
 
 type VaultSecretManagerConfig struct {
 	Role        string            `json:"role" pflag:",Specifies the vault role to use"`
-	KVVersion   KVVersion         `json:"kvVersion" pflag:"-,The KV Engine Version. Defaults to 2. Use 1 for unversioned secrets. Refer to - https://www.vaultproject.io/docs/secrets/kv#kv-secrets-engine."`
+	KVVersion   KVVersion         `json:"kvVersion" pflag:"-,DEPRECATED! Use the GroupVersion field of the Secret request instead. The KV Engine Version. Defaults to 2. Use 1 for unversioned secrets. Refer to - https://www.vaultproject.io/docs/secrets/kv#kv-secrets-engine."`
 	Annotations map[string]string `json:"annotations" pflag:"-,Annotation to be added to user task pod. The annotation can also be used to override default annotations added by Flyte. Useful to customize Vault integration (https://developer.hashicorp.com/vault/docs/platform/k8s/injector/annotations)"`
 }
 

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -123,30 +123,42 @@ func AppendVolume(volumes []corev1.Volume, volume corev1.Volume) []corev1.Volume
 	return append(volumes, volume)
 }
 
-func CreateVaultAnnotationsForSecret(secret *core.Secret, kvversion config.KVVersion) (map[string]string, error) {
+func CreateVaultAnnotationsForSecret(secret *core.Secret, kvversion config.KVVersion) map[string]string {
 	// Creates three grouped annotations "agent-inject-secret", "agent-inject-file" and "agent-inject-template"
 	// for a given secret request and KV engine version. The annotations respectively handle: 1. retrieving the
 	// secret from a vault path specified in secret.Group, 2. storing it in a file named after secret.Group/secret.Key
 	// and 3. creating a template that retrieves only secret.Key from the multiple k:v pairs present in a vault secret.
 	id := string(uuid.NewUUID())
 
+	secretVaultAnnotations := map[string]string{
+		fmt.Sprintf("vault.hashicorp.com/agent-inject-secret-%s", id): secret.Group,
+		fmt.Sprintf("vault.hashicorp.com/agent-inject-file-%s", id):   fmt.Sprintf("%s/%s", secret.Group, secret.Key),
+	}
+
 	// Set the consul template language query depending on the KV Secrets Engine version.
 	// Version 1 stores plain k:v pairs under .Data, version 2 supports versioned secrets
 	// and wraps the k:v pairs into an additional subfield.
 	var query string
-	if kvversion == config.KVVersion1 {
+	switch secret.GroupVersion {
+	case "kv1":
 		query = ".Data"
-	} else if kvversion == config.KVVersion2 {
+	case "kv2":
 		query = ".Data.data"
-	} else {
-		err := fmt.Errorf("unsupported KV Version %v, supported versions are 1 and 2", kvversion)
-		return nil, err
+	case "db":
+		// For the database secrets engine backend we do not want to use the templating
+	default:
+		// Support using the legacy KVVersion config if GroupVersion is not set
+		switch kvversion {
+		case config.KVVersion1:
+			query = ".Data"
+		case config.KVVersion2:
+			query = ".Data.data"
+		}
 	}
-	template := fmt.Sprintf(`{{- with secret "%s" -}}{{ %s.%s }}{{- end -}}`, secret.Group, query, secret.Key)
-	secretVaultAnnotations := map[string]string{
-		fmt.Sprintf("vault.hashicorp.com/agent-inject-secret-%s", id):   secret.Group,
-		fmt.Sprintf("vault.hashicorp.com/agent-inject-file-%s", id):     fmt.Sprintf("%s/%s", secret.Group, secret.Key),
-		fmt.Sprintf("vault.hashicorp.com/agent-inject-template-%s", id): template,
+	if query != "" {
+		template := fmt.Sprintf(`{{- with secret "%s" -}}{{ %s.%s }}{{- end -}}`, secret.Group, query, secret.Key)
+		secretVaultAnnotations[fmt.Sprintf("vault.hashicorp.com/agent-inject-template-%s", id)] = template
+
 	}
-	return secretVaultAnnotations, nil
+	return secretVaultAnnotations
 }

--- a/pkg/webhook/utils.go
+++ b/pkg/webhook/utils.go
@@ -147,6 +147,8 @@ func CreateVaultAnnotationsForSecret(secret *core.Secret, kvversion config.KVVer
 	case "db":
 		// For the database secrets engine backend we do not want to use the templating
 	default:
+		// Deprecated: The config setting KVVersion is deprecated and will be removed in a future release.
+		// You should instead use the GroupVersion field in the secret definition.
 		// Support using the legacy KVVersion config if GroupVersion is not set
 		switch kvversion {
 		case config.KVVersion1:

--- a/pkg/webhook/vault_secret_manager.go
+++ b/pkg/webhook/vault_secret_manager.go
@@ -68,11 +68,7 @@ func (i VaultSecretManagerInjector) Inject(ctx context.Context, secret *coreIdl.
 			"vault.hashicorp.com/agent-pre-populate-only": "true",
 		}
 
-		secretVaultAnnotations, err := CreateVaultAnnotationsForSecret(secret, i.cfg.KVVersion)
-		// Creating annotations can break with an unsupported KVVersion
-		if err != nil {
-			return p, false, err
-		}
+		secretVaultAnnotations := CreateVaultAnnotationsForSecret(secret, i.cfg.KVVersion)
 
 		p.ObjectMeta.Annotations = utils.UnionMaps(secretVaultAnnotations, commonVaultAnnotations, i.cfg.Annotations, p.ObjectMeta.Annotations)
 

--- a/pkg/webhook/vault_secret_manager_test.go
+++ b/pkg/webhook/vault_secret_manager_test.go
@@ -255,16 +255,6 @@ func TestVaultSecretManagerInjector_Inject(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Unsupported KV version fails",
-			args: args{
-				cfg:    config.VaultSecretManagerConfig{Role: "flyte", KVVersion: 3},
-				secret: inputSecret,
-				p:      NewInputPod(map[string]string{}),
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
 			name: "DB Secret backend enginge is supported",
 			args: args{
 				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion1},

--- a/pkg/webhook/vault_secret_manager_test.go
+++ b/pkg/webhook/vault_secret_manager_test.go
@@ -120,7 +120,6 @@ func ExpectedExistingRoleAnnotation(uuid string) *corev1.Pod {
 }
 
 func ExpectedConfigAnnotation(uuid string) *corev1.Pod {
-	// Injects uuid into expected output for KV v2 secrets
 	expected := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{

--- a/pkg/webhook/vault_secret_manager_test.go
+++ b/pkg/webhook/vault_secret_manager_test.go
@@ -82,8 +82,7 @@ func ExpectedKVv2(uuid string) *corev1.Pod {
 	return expected
 }
 
-func ExpectedKVv3(uuid string) *corev1.Pod {
-	// Injects uuid into expected output for KV v2 secrets
+func ExpectedExtraAnnotation(uuid string) *corev1.Pod {
 	expected := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -102,8 +101,7 @@ func ExpectedKVv3(uuid string) *corev1.Pod {
 	return expected
 }
 
-func ExpectedKVv4(uuid string) *corev1.Pod {
-	// Injects uuid into expected output for KV v2 secrets
+func ExpectedExistingRoleAnnotation(uuid string) *corev1.Pod {
 	expected := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -121,7 +119,7 @@ func ExpectedKVv4(uuid string) *corev1.Pod {
 	return expected
 }
 
-func ExpectedKVv5(uuid string) *corev1.Pod {
+func ExpectedConfigAnnotation(uuid string) *corev1.Pod {
 	// Injects uuid into expected output for KV v2 secrets
 	expected := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -133,6 +131,23 @@ func ExpectedKVv5(uuid string) *corev1.Pod {
 				fmt.Sprintf("vault.hashicorp.com/agent-inject-secret-%s", uuid):   "foo",
 				fmt.Sprintf("vault.hashicorp.com/agent-inject-file-%s", uuid):     "foo/bar",
 				fmt.Sprintf("vault.hashicorp.com/agent-inject-template-%s", uuid): `{{- with secret "foo" -}}{{ .Data.data.bar }}{{- end -}}`,
+			},
+		},
+		Spec: PodSpec,
+	}
+	return expected
+}
+
+func ExpectedDB(uuid string) *corev1.Pod {
+	expected := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"vault.hashicorp.com/agent-inject":                              "true",
+				"vault.hashicorp.com/secret-volume-path":                        "/etc/flyte/secrets",
+				"vault.hashicorp.com/role":                                      "flyte",
+				"vault.hashicorp.com/agent-pre-populate-only":                   "true",
+				fmt.Sprintf("vault.hashicorp.com/agent-inject-secret-%s", uuid): "foo",
+				fmt.Sprintf("vault.hashicorp.com/agent-inject-file-%s", uuid):   "foo/bar",
 			},
 		},
 		Spec: PodSpec,
@@ -176,27 +191,35 @@ func TestVaultSecretManagerInjector_Inject(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "KVv1 Secret",
+			name: "KVv1 Secret Group Version argument overwrites config",
 			args: args{
-				cfg:    config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion1},
-				secret: inputSecret,
-				p:      NewInputPod(map[string]string{}),
+				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion2},
+				secret: &coreIdl.Secret{
+					Group:        "foo",
+					Key:          "bar",
+					GroupVersion: "kv1",
+				},
+				p: NewInputPod(map[string]string{}),
 			},
 			want:    ExpectedKVv1,
 			wantErr: false,
 		},
 		{
-			name: "KVv2 Secret",
+			name: "KVv2 Secret Group Version argument overwrites config",
 			args: args{
-				cfg:    config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion2},
-				secret: inputSecret,
-				p:      NewInputPod(map[string]string{}),
+				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion1},
+				secret: &coreIdl.Secret{
+					Group:        "foo",
+					Key:          "bar",
+					GroupVersion: "kv2",
+				},
+				p: NewInputPod(map[string]string{}),
 			},
 			want:    ExpectedKVv2,
 			wantErr: false,
 		},
 		{
-			name: "KVv3 Secret - extra annotations",
+			name: "Extra annotations from config are added",
 			args: args{
 				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion2, Annotations: map[string]string{
 					"vault.hashicorp.com/auth-config-type": "gce",
@@ -204,11 +227,11 @@ func TestVaultSecretManagerInjector_Inject(t *testing.T) {
 				secret: inputSecret,
 				p:      NewInputPod(map[string]string{}),
 			},
-			want:    ExpectedKVv3,
+			want:    ExpectedExtraAnnotation,
 			wantErr: false,
 		},
 		{
-			name: "KVv4 Secret - user override annotation",
+			name: "Already present annotation is not overwritten",
 			args: args{
 				cfg:    config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion2, Annotations: map[string]string{}},
 				secret: inputSecret,
@@ -216,11 +239,11 @@ func TestVaultSecretManagerInjector_Inject(t *testing.T) {
 					"vault.hashicorp.com/role": "my-role",
 				}),
 			},
-			want:    ExpectedKVv4,
+			want:    ExpectedExistingRoleAnnotation,
 			wantErr: false,
 		},
 		{
-			name: "KVv5 Secret - system override annotation",
+			name: "Config annotation overwrites system default annotation",
 			args: args{
 				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion2, Annotations: map[string]string{
 					"vault.hashicorp.com/agent-pre-populate-only": "false", // override vault.hashicorp.com/agent-pre-populate-only
@@ -228,11 +251,11 @@ func TestVaultSecretManagerInjector_Inject(t *testing.T) {
 				secret: inputSecret,
 				p:      NewInputPod(map[string]string{}),
 			},
-			want:    ExpectedKVv5,
+			want:    ExpectedConfigAnnotation,
 			wantErr: false,
 		},
 		{
-			name: "Unsupported KV version",
+			name: "Unsupported KV version fails",
 			args: args{
 				cfg:    config.VaultSecretManagerConfig{Role: "flyte", KVVersion: 3},
 				secret: inputSecret,
@@ -240,6 +263,46 @@ func TestVaultSecretManagerInjector_Inject(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "DB Secret backend enginge is supported",
+			args: args{
+				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion1},
+				secret: &coreIdl.Secret{
+					Group:        "foo",
+					Key:          "bar",
+					GroupVersion: "db",
+				},
+				p: NewInputPod(map[string]string{}),
+			},
+			want:    ExpectedDB,
+			wantErr: false,
+		},
+		{
+			name: "Legacy config option V1 is still supported",
+			args: args{
+				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion1},
+				secret: &coreIdl.Secret{
+					Group: "foo",
+					Key:   "bar",
+				},
+				p: NewInputPod(map[string]string{}),
+			},
+			want:    ExpectedKVv1,
+			wantErr: false,
+		},
+		{
+			name: "Legacy config option V2 is still supported",
+			args: args{
+				cfg: config.VaultSecretManagerConfig{Role: "flyte", KVVersion: config.KVVersion2},
+				secret: &coreIdl.Secret{
+					Group: "foo",
+					Key:   "bar",
+				},
+				p: NewInputPod(map[string]string{}),
+			},
+			want:    ExpectedKVv2,
+			wantErr: false,
 		},
 	}
 

--- a/pkg/webhook/vault_secret_manager_test.go
+++ b/pkg/webhook/vault_secret_manager_test.go
@@ -45,7 +45,6 @@ func RetrieveUUID(annotations map[string]string) string {
 }
 
 func ExpectedKVv1(uuid string) *corev1.Pod {
-	// Injects uuid into expected output for KV v1 secrets
 	expected := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -64,7 +63,6 @@ func ExpectedKVv1(uuid string) *corev1.Pod {
 }
 
 func ExpectedKVv2(uuid string) *corev1.Pod {
-	// Injects uuid into expected output for KV v2 secrets
 	expected := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{


### PR DESCRIPTION
# TL;DR
Removes the KV Version config parameter and instead uses the Secret `group` field to allow using both (and other Vault secret backends) dynamically. 
This also allows using the [Database Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/databases), which effectively means noop since we want to read the whole credential and not just a specific key.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
[The Secret protobuf defines a group field](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/security.proto#L33) which we have previously ignored. Leveraging that field allows to simplify the secret manager config and allows supporting multiple Vault secret backends dynamically by deciding what secret template to inject based on the optional `group` parameter.

This is a breaking change for people using the previous version of the Vault Secret Manager. To migrate they will need to remove the `kvVersion` key from their propeller configs and specify the appropriate group version in their secret requests, like for example so:

```python
@task(
    secret_requests=[
        Secret(group="foo", key="bar", group_version="kv2"),
    ]
)
```

## Follow-up issue
_NA_

