### PR TITLE
persisting k8s plugin state between evaluations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -148,4 +148,4 @@ require (
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
 
-replace github.com/flyteorg/flyteplugins => github.com/flyteorg/flyteplugins v1.0.41-0.20230313213632-e021db003b46
+replace github.com/flyteorg/flyteplugins => github.com/flyteorg/flyteplugins v1.0.41-0.20230314215832-73c496550087

--- a/go.mod
+++ b/go.mod
@@ -147,3 +147,5 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteplugins => github.com/flyteorg/flyteplugins v1.0.41-0.20230313213632-e021db003b46

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/DiSiqueira/GoTree v1.0.1-0.20180907134536-53a8e837f295
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.13.0
-	github.com/flyteorg/flyteidl v1.3.9
-	github.com/flyteorg/flyteplugins v1.0.40
+	github.com/flyteorg/flyteidl v1.3.14
+	github.com/flyteorg/flyteplugins v1.0.44
 	github.com/flyteorg/flytestdlib v1.0.15
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible
@@ -147,5 +147,3 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
-
-replace github.com/flyteorg/flyteplugins => github.com/flyteorg/flyteplugins v1.0.41-0.20230314215832-73c496550087

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.3.9 h1:MHUa89yKwCz58mQC2OxTzYjr0d3fA14qKG462v+RAyk=
 github.com/flyteorg/flyteidl v1.3.9/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
-github.com/flyteorg/flyteplugins v1.0.41-0.20230313213632-e021db003b46 h1:4OVLZ+yvm7QJVyiFkaEzaR80fkcrN6xOagFdnFO/dDQ=
-github.com/flyteorg/flyteplugins v1.0.41-0.20230313213632-e021db003b46/go.mod h1:qyUPqVspLcLGJpKxVwHDWf+kBpOGuItOxCaF6zAmDio=
+github.com/flyteorg/flyteplugins v1.0.41-0.20230314215832-73c496550087 h1:rgOGaYVQTOe/HJbChlQt/LcURQnmSk7JpBsUPSsDHnM=
+github.com/flyteorg/flyteplugins v1.0.41-0.20230314215832-73c496550087/go.mod h1:qyUPqVspLcLGJpKxVwHDWf+kBpOGuItOxCaF6zAmDio=
 github.com/flyteorg/flytestdlib v1.0.15 h1:kv9jDQmytbE84caY+pkZN8trJU2ouSAmESzpTEhfTt0=
 github.com/flyteorg/flytestdlib v1.0.15/go.mod h1:ghw/cjY0sEWIIbyCtcJnL/Gt7ZS7gf9SUi0CCPhbz3s=
 github.com/flyteorg/stow v0.3.6 h1:jt50ciM14qhKBaIrB+ppXXY+SXB59FNREFgTJqCyqIk=

--- a/go.sum
+++ b/go.sum
@@ -260,10 +260,10 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flyteorg/flyteidl v1.3.9 h1:MHUa89yKwCz58mQC2OxTzYjr0d3fA14qKG462v+RAyk=
-github.com/flyteorg/flyteidl v1.3.9/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
-github.com/flyteorg/flyteplugins v1.0.41-0.20230314215832-73c496550087 h1:rgOGaYVQTOe/HJbChlQt/LcURQnmSk7JpBsUPSsDHnM=
-github.com/flyteorg/flyteplugins v1.0.41-0.20230314215832-73c496550087/go.mod h1:qyUPqVspLcLGJpKxVwHDWf+kBpOGuItOxCaF6zAmDio=
+github.com/flyteorg/flyteidl v1.3.14 h1:o5M0g/r6pXTPu5PEurbYxbQmuOu3hqqsaI2M6uvK0N8=
+github.com/flyteorg/flyteidl v1.3.14/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
+github.com/flyteorg/flyteplugins v1.0.44 h1:uKizng+i0vfXslyPBlrsfecInhvy71fTB4kRg7eiifE=
+github.com/flyteorg/flyteplugins v1.0.44/go.mod h1:ztsonku5fKwyxcIg1k69PTiBVjRI6d3nK5DnC+iwx08=
 github.com/flyteorg/flytestdlib v1.0.15 h1:kv9jDQmytbE84caY+pkZN8trJU2ouSAmESzpTEhfTt0=
 github.com/flyteorg/flytestdlib v1.0.15/go.mod h1:ghw/cjY0sEWIIbyCtcJnL/Gt7ZS7gf9SUi0CCPhbz3s=
 github.com/flyteorg/stow v0.3.6 h1:jt50ciM14qhKBaIrB+ppXXY+SXB59FNREFgTJqCyqIk=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.3.9 h1:MHUa89yKwCz58mQC2OxTzYjr0d3fA14qKG462v+RAyk=
 github.com/flyteorg/flyteidl v1.3.9/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
-github.com/flyteorg/flyteplugins v1.0.40 h1:RTsYingqmqr13qBbi4CB2ArXDHNHUOkAF+HTLJQiQ/s=
-github.com/flyteorg/flyteplugins v1.0.40/go.mod h1:qyUPqVspLcLGJpKxVwHDWf+kBpOGuItOxCaF6zAmDio=
+github.com/flyteorg/flyteplugins v1.0.41-0.20230313213632-e021db003b46 h1:4OVLZ+yvm7QJVyiFkaEzaR80fkcrN6xOagFdnFO/dDQ=
+github.com/flyteorg/flyteplugins v1.0.41-0.20230313213632-e021db003b46/go.mod h1:qyUPqVspLcLGJpKxVwHDWf+kBpOGuItOxCaF6zAmDio=
 github.com/flyteorg/flytestdlib v1.0.15 h1:kv9jDQmytbE84caY+pkZN8trJU2ouSAmESzpTEhfTt0=
 github.com/flyteorg/flytestdlib v1.0.15/go.mod h1:ghw/cjY0sEWIIbyCtcJnL/Gt7ZS7gf9SUi0CCPhbz3s=
 github.com/flyteorg/stow v0.3.6 h1:jt50ciM14qhKBaIrB+ppXXY+SXB59FNREFgTJqCyqIk=

--- a/pkg/controller/nodes/task/k8s/plugin_context.go
+++ b/pkg/controller/nodes/task/k8s/plugin_context.go
@@ -28,17 +28,17 @@ func (p *pluginContext) OutputWriter() io.OutputWriter {
 	return buf
 }
 
-// TODO @hamersaw docs
+// pluginStateReader overrides the default PluginStateReader to return a pre-assigned PluginState. This allows us to
+// encapsulate plugin state persistence in the existing k8s PluginManager and only expose the ability to read the
+// previous Phase, PhaseVersion, and Reason for all k8s plugins.
 type pluginStateReader struct {
 	k8sPluginState *k8s.PluginState
 }
 
-// TODO @hamersaw docs
 func (p pluginStateReader) GetStateVersion() uint8 {
 	return 0
 }
 
-// TODO @hamersaw docs
 func (p pluginStateReader) Get(t interface{}) (stateVersion uint8, err error) {
 	if pointer, ok := t.(*k8s.PluginState); ok {
 		*pointer = *p.k8sPluginState
@@ -49,7 +49,7 @@ func (p pluginStateReader) Get(t interface{}) (stateVersion uint8, err error) {
 	return 0, nil
 }
 
-// TODO @hamersaw docs
+// PluginStateReader overrides the default behavior to return our k8s plugin specific reader.
 func (p *pluginContext) PluginStateReader() pluginsCore.PluginStateReader {
 	return pluginStateReader{
 		k8sPluginState: p.k8sPluginState,

--- a/pkg/controller/nodes/task/k8s/plugin_context.go
+++ b/pkg/controller/nodes/task/k8s/plugin_context.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 
 	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
@@ -15,7 +16,7 @@ var _ k8s.PluginContext = &pluginContext{}
 type pluginContext struct {
 	pluginsCore.TaskExecutionContext
 	// Lazily creates a buffered outputWriter, overriding the input outputWriter.
-	ow *ioutils.BufferedOutputWriter
+	ow             *ioutils.BufferedOutputWriter
 	k8sPluginState *k8s.PluginState
 }
 
@@ -34,7 +35,7 @@ type pluginStateReader struct {
 
 // TODO @hamersaw docs
 func (p pluginStateReader) GetStateVersion() uint8 {
-	return 0;
+	return 0
 }
 
 // TODO @hamersaw docs
@@ -42,7 +43,7 @@ func (p pluginStateReader) Get(t interface{}) (stateVersion uint8, err error) {
 	if pointer, ok := t.(*k8s.PluginState); ok {
 		*pointer = *p.k8sPluginState
 	} else {
-		// TODO @hamersaw err
+		return 0, fmt.Errorf("unexpected type when reading plugin state")
 	}
 
 	return 0, nil
@@ -50,7 +51,7 @@ func (p pluginStateReader) Get(t interface{}) (stateVersion uint8, err error) {
 
 // TODO @hamersaw docs
 func (p *pluginContext) PluginStateReader() pluginsCore.PluginStateReader {
-	return  pluginStateReader {
+	return pluginStateReader{
 		k8sPluginState: p.k8sPluginState,
 	}
 }

--- a/pkg/controller/nodes/task/k8s/plugin_context.go
+++ b/pkg/controller/nodes/task/k8s/plugin_context.go
@@ -16,6 +16,7 @@ type pluginContext struct {
 	pluginsCore.TaskExecutionContext
 	// Lazily creates a buffered outputWriter, overriding the input outputWriter.
 	ow *ioutils.BufferedOutputWriter
+	k8sPluginState *k8s.PluginState
 }
 
 // Provides an output sync of type io.OutputWriter
@@ -26,9 +27,38 @@ func (p *pluginContext) OutputWriter() io.OutputWriter {
 	return buf
 }
 
-func newPluginContext(tCtx pluginsCore.TaskExecutionContext) *pluginContext {
+// TODO @hamersaw docs
+type pluginStateReader struct {
+	k8sPluginState *k8s.PluginState
+}
+
+// TODO @hamersaw docs
+func (p pluginStateReader) GetStateVersion() uint8 {
+	return 0;
+}
+
+// TODO @hamersaw docs
+func (p pluginStateReader) Get(t interface{}) (stateVersion uint8, err error) {
+	if pointer, ok := t.(*k8s.PluginState); ok {
+		*pointer = *p.k8sPluginState
+	} else {
+		// TODO @hamersaw err
+	}
+
+	return 0, nil
+}
+
+// TODO @hamersaw docs
+func (p *pluginContext) PluginStateReader() pluginsCore.PluginStateReader {
+	return  pluginStateReader {
+		k8sPluginState: p.k8sPluginState,
+	}
+}
+
+func newPluginContext(tCtx pluginsCore.TaskExecutionContext, k8sPluginState *k8s.PluginState) *pluginContext {
 	return &pluginContext{
 		TaskExecutionContext: tCtx,
 		ow:                   nil,
+		k8sPluginState:       k8sPluginState,
 	}
 }

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -59,7 +59,8 @@ const (
 )
 
 type PluginState struct {
-	Phase PluginPhase
+	Phase          PluginPhase
+	K8sPluginState k8s.PluginState
 }
 
 type PluginMetrics struct {
@@ -247,7 +248,7 @@ func (e *PluginManager) LaunchResource(ctx context.Context, tCtx pluginsCore.Tas
 	return pluginsCore.DoTransition(pluginsCore.PhaseInfoQueued(time.Now(), pluginsCore.DefaultPhaseVersion, "task submitted to K8s")), nil
 }
 
-func (e *PluginManager) CheckResourcePhase(ctx context.Context, tCtx pluginsCore.TaskExecutionContext) (pluginsCore.Transition, error) {
+func (e *PluginManager) CheckResourcePhase(ctx context.Context, tCtx pluginsCore.TaskExecutionContext, k8sPluginState *k8s.PluginState) (pluginsCore.Transition, error) {
 
 	o, err := e.plugin.BuildIdentityResource(ctx, tCtx.TaskExecutionMetadata())
 	if err != nil {
@@ -274,7 +275,7 @@ func (e *PluginManager) CheckResourcePhase(ctx context.Context, tCtx pluginsCore
 		e.metrics.ResourceDeleted.Inc(ctx)
 	}
 
-	pCtx := newPluginContext(tCtx)
+	pCtx := newPluginContext(tCtx, k8sPluginState)
 	p, err := e.plugin.GetTaskPhase(ctx, pCtx, o)
 	if err != nil {
 		logger.Warnf(ctx, "failed to check status of resource in plugin [%s], with error: %s", e.GetID(), err.Error())
@@ -311,6 +312,7 @@ func (e *PluginManager) CheckResourcePhase(ctx context.Context, tCtx pluginsCore
 }
 
 func (e PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecutionContext) (pluginsCore.Transition, error) {
+	// read phase state
 	ps := PluginState{}
 	if v, err := tCtx.PluginStateReader().Get(&ps); err != nil {
 		if v != pluginStateVersion {
@@ -318,7 +320,45 @@ func (e PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecutio
 		}
 		return pluginsCore.UnknownTransition, errors.Wrapf(errors.CorruptedPluginState, err, "Failed to read unmarshal custom state")
 	}
+
+	// evaluate plugin
+	var err error
+	var transition pluginsCore.Transition
+	pluginPhase := ps.Phase
 	if ps.Phase == PluginPhaseNotStarted {
+		transition, err = e.LaunchResource(ctx, tCtx)
+		pluginPhase = PluginPhaseStarted
+	} else {
+		transition, err = e.CheckResourcePhase(ctx, tCtx, &ps.K8sPluginState)
+	}
+
+	if err != nil {
+		return transition, err
+	}
+
+	// persist any changes in phase state
+	k8sPluginState := ps.K8sPluginState
+	if ps.Phase != pluginPhase || k8sPluginState.Phase != transition.Info().Phase() || 
+		k8sPluginState.PhaseVersion != transition.Info().Version() || k8sPluginState.Reason != transition.Info().Reason() {
+
+		newPluginState := PluginState{
+			Phase:          pluginPhase,
+			K8sPluginState: k8s.PluginState{
+				Phase:        transition.Info().Phase(),
+				PhaseVersion: transition.Info().Version(),
+				Reason:       transition.Info().Reason(),
+			},
+		}
+
+		if err := tCtx.PluginStateWriter().Put(pluginStateVersion, &newPluginState); err != nil {
+			return pluginsCore.UnknownTransition, err
+		}
+	}
+
+	return transition, err
+
+	// TODO @hamersaw - dead code
+	/*if ps.Phase == PluginPhaseNotStarted {
 		t, err := e.LaunchResource(ctx, tCtx)
 		if err == nil && t.Info().Phase() == pluginsCore.PhaseQueued {
 			if err := tCtx.PluginStateWriter().Put(pluginStateVersion, &PluginState{Phase: PluginPhaseStarted}); err != nil {
@@ -327,7 +367,7 @@ func (e PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecutio
 		}
 		return t, err
 	}
-	return e.CheckResourcePhase(ctx, tCtx)
+	return e.CheckResourcePhase(ctx, tCtx)*/
 }
 
 func (e PluginManager) Abort(ctx context.Context, tCtx pluginsCore.TaskExecutionContext) error {

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -358,18 +358,6 @@ func (e PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecutio
 	}
 
 	return transition, err
-
-	// TODO @hamersaw - dead code
-	/*if ps.Phase == PluginPhaseNotStarted {
-		t, err := e.LaunchResource(ctx, tCtx)
-		if err == nil && t.Info().Phase() == pluginsCore.PhaseQueued {
-			if err := tCtx.PluginStateWriter().Put(pluginStateVersion, &PluginState{Phase: PluginPhaseStarted}); err != nil {
-				return pluginsCore.UnknownTransition, err
-			}
-		}
-		return t, err
-	}
-	return e.CheckResourcePhase(ctx, tCtx)*/
 }
 
 func (e PluginManager) Abort(ctx context.Context, tCtx pluginsCore.TaskExecutionContext) error {

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -327,7 +327,9 @@ func (e PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecutio
 	pluginPhase := ps.Phase
 	if ps.Phase == PluginPhaseNotStarted {
 		transition, err = e.LaunchResource(ctx, tCtx)
-		pluginPhase = PluginPhaseStarted
+		if err == nil && transition.Info().Phase() == pluginsCore.PhaseQueued {
+			pluginPhase = PluginPhaseStarted
+		}
 	} else {
 		transition, err = e.CheckResourcePhase(ctx, tCtx, &ps.K8sPluginState)
 	}
@@ -338,11 +340,11 @@ func (e PluginManager) Handle(ctx context.Context, tCtx pluginsCore.TaskExecutio
 
 	// persist any changes in phase state
 	k8sPluginState := ps.K8sPluginState
-	if ps.Phase != pluginPhase || k8sPluginState.Phase != transition.Info().Phase() || 
+	if ps.Phase != pluginPhase || k8sPluginState.Phase != transition.Info().Phase() ||
 		k8sPluginState.PhaseVersion != transition.Info().Version() || k8sPluginState.Reason != transition.Info().Reason() {
 
 		newPluginState := PluginState{
-			Phase:          pluginPhase,
+			Phase: pluginPhase,
 			K8sPluginState: k8s.PluginState{
 				Phase:        transition.Info().Phase(),
 				PhaseVersion: transition.Info().Version(),


### PR DESCRIPTION
# TL;DR
Persisting k8s plugin state by embedding it in the overall state stored for all k8s plugins. The exporting the `PluginStateReader` function through the `PluginContext` so that k8s plugin writers can retrieve plugin state the same way they do in other plugins, just that persistend (ie. `PluginStateWriter`) is performed underneath.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3440

## Follow-up issue
_NA_
