### PR TITLE
Remove resource injection on the node for container task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.13.0
 	github.com/flyteorg/flyteidl v1.3.14
-	github.com/flyteorg/flyteplugins v1.0.48
+	github.com/flyteorg/flyteplugins v1.0.47
 	github.com/flyteorg/flytestdlib v1.0.15
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.13.0
 	github.com/flyteorg/flyteidl v1.3.14
-	github.com/flyteorg/flyteplugins v1.0.45
+	github.com/flyteorg/flyteplugins v1.0.48
 	github.com/flyteorg/flytestdlib v1.0.15
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.3.14 h1:o5M0g/r6pXTPu5PEurbYxbQmuOu3hqqsaI2M6uvK0N8=
 github.com/flyteorg/flyteidl v1.3.14/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
-github.com/flyteorg/flyteplugins v1.0.45 h1:I/N4ehOxX6ln8DivyZ9gayp/UYiBcqoizBbG1hfwIXM=
-github.com/flyteorg/flyteplugins v1.0.45/go.mod h1:ztsonku5fKwyxcIg1k69PTiBVjRI6d3nK5DnC+iwx08=
+github.com/flyteorg/flyteplugins v1.0.48 h1:2r1dxp6WMnANQNgAGVQwYnRu6YDKJ0R+DbCeoZAng5Q=
+github.com/flyteorg/flyteplugins v1.0.48/go.mod h1:ztsonku5fKwyxcIg1k69PTiBVjRI6d3nK5DnC+iwx08=
 github.com/flyteorg/flytestdlib v1.0.15 h1:kv9jDQmytbE84caY+pkZN8trJU2ouSAmESzpTEhfTt0=
 github.com/flyteorg/flytestdlib v1.0.15/go.mod h1:ghw/cjY0sEWIIbyCtcJnL/Gt7ZS7gf9SUi0CCPhbz3s=
 github.com/flyteorg/stow v0.3.6 h1:jt50ciM14qhKBaIrB+ppXXY+SXB59FNREFgTJqCyqIk=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.3.14 h1:o5M0g/r6pXTPu5PEurbYxbQmuOu3hqqsaI2M6uvK0N8=
 github.com/flyteorg/flyteidl v1.3.14/go.mod h1:Pkt2skI1LiHs/2ZoekBnyPhuGOFMiuul6HHcKGZBsbM=
-github.com/flyteorg/flyteplugins v1.0.48 h1:2r1dxp6WMnANQNgAGVQwYnRu6YDKJ0R+DbCeoZAng5Q=
-github.com/flyteorg/flyteplugins v1.0.48/go.mod h1:ztsonku5fKwyxcIg1k69PTiBVjRI6d3nK5DnC+iwx08=
+github.com/flyteorg/flyteplugins v1.0.47 h1:+SnRM7Z257xiIg5B5i3gLJxEUtZJlEyrzCPCAMolsug=
+github.com/flyteorg/flyteplugins v1.0.47/go.mod h1:ztsonku5fKwyxcIg1k69PTiBVjRI6d3nK5DnC+iwx08=
 github.com/flyteorg/flytestdlib v1.0.15 h1:kv9jDQmytbE84caY+pkZN8trJU2ouSAmESzpTEhfTt0=
 github.com/flyteorg/flytestdlib v1.0.15/go.mod h1:ghw/cjY0sEWIIbyCtcJnL/Gt7ZS7gf9SUi0CCPhbz3s=
 github.com/flyteorg/stow v0.3.6 h1:jt50ciM14qhKBaIrB+ppXXY+SXB59FNREFgTJqCyqIk=

--- a/pkg/compiler/transformers/k8s/node.go
+++ b/pkg/compiler/transformers/k8s/node.go
@@ -45,8 +45,6 @@ func buildNodeSpec(n *core.Node, tasks []*core.CompiledTask, errs errors.Compile
 
 		if n.GetTaskNode().Overrides != nil && n.GetTaskNode().Overrides.Resources != nil {
 			resources = n.GetTaskNode().Overrides.Resources
-		} else {
-			resources = getResources(task)
 		}
 	}
 

--- a/pkg/compiler/transformers/k8s/node_test.go
+++ b/pkg/compiler/transformers/k8s/node_test.go
@@ -93,22 +93,6 @@ func TestBuildNodeSpec(t *testing.T) {
 		mustBuild(t, n, 1, errs.NewScope())
 	})
 
-	t.Run("Task with resources", func(t *testing.T) {
-		expectedCPU := resource.MustParse("10Mi")
-		n.Node.Target = &core.Node_TaskNode{
-			TaskNode: &core.TaskNode{
-				Reference: &core.TaskNode_ReferenceId{
-					ReferenceId: &core.Identifier{Name: "ref_2"},
-				},
-			},
-		}
-
-		spec := mustBuild(t, n, 1, errs.NewScope())
-		assert.NotNil(t, spec.Resources)
-		assert.NotNil(t, spec.Resources.Requests.Cpu())
-		assert.Equal(t, expectedCPU.Value(), spec.Resources.Requests.Cpu().Value())
-	})
-
 	t.Run("node with resource overrides", func(t *testing.T) {
 		expectedCPU := resource.MustParse("20Mi")
 		n.Node.Target = &core.Node_TaskNode{

--- a/pkg/compiler/transformers/k8s/utils.go
+++ b/pkg/compiler/transformers/k8s/utils.go
@@ -48,18 +48,6 @@ func computeDeadline(n *core.Node) (*v1.Duration, error) {
 	return deadline, nil
 }
 
-func getResources(task *core.TaskTemplate) *core.Resources {
-	if task == nil {
-		return nil
-	}
-
-	if task.GetContainer() == nil {
-		return nil
-	}
-
-	return task.GetContainer().Resources
-}
-
 func toAliasValueArray(aliases []*core.Alias) []v1alpha1.Alias {
 	if aliases == nil {
 		return nil


### PR DESCRIPTION
# TL;DR

Remove resource injection on the node for container task

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_


In [BuildRawContainer](https://github.com/flyteorg/flyteplugins/blob/master/go/tasks/pluginmachinery/flytek8s/container_helper.go#L213), we do not inject the container resource from the  task template. Instead, we inject the resource from [parameters.TaskExecMetadata.GetOverrides().GetResources()](https://github.com/flyteorg/flytepropeller/blob/master/pkg/compiler/transformers/k8s/node.go#L49).

This is because for both `_with_override(resource=...` and `@task(requests=...)`, they are both inject as the node resource override in [buildNodeSpec](https://github.com/flyteorg/flytepropeller/blob/master/pkg/compiler/transformers/k8s/node.go#L49)

### Expected behavior

For the case of `@task(requests=...)`, the resource override on the node should be empty, and the resource is injected from tasktemplate at [BuildRawContainer](https://github.com/flyteorg/flyteplugins/blob/master/go/tasks/pluginmachinery/flytek8s/container_helper.go#L213)

## Tracking Issue

https://github.com/flyteorg/flyte/issues/3540