### PR TITLE
Moved controller-runtime start out of webhook Run function

### DIFF
--- a/cmd/controller/cmd/webhook.go
+++ b/cmd/controller/cmd/webhook.go
@@ -131,6 +131,14 @@ func runWebhook(origContext context.Context, propellerCfg *config.Config, cfg *w
 	})
 
 	g.Go(func() error {
+		err := controller.StartControllerManager(childCtx, mgr)
+		if err != nil {
+			logger.Fatalf(childCtx, "Failed to start controller manager. Error: %v", err)
+		}
+		return err
+	})
+
+	g.Go(func() error {
 		err := webhook.Run(childCtx, propellerCfg, cfg, defaultNamespace, &webhookScope, mgr)
 		if err != nil {
 			logger.Fatalf(childCtx, "Failed to start webhook. Error: %v", err)

--- a/pkg/webhook/entrypoint.go
+++ b/pkg/webhook/entrypoint.go
@@ -52,8 +52,10 @@ func Run(ctx context.Context, propellerCfg *config.Config, cfg *config2.Config,
 		logger.Fatalf(ctx, "Failed to register webhook with manager. Error: %v", err)
 	}
 
-	logger.Infof(ctx, "Starting controller-runtime manager")
-	return (*mgr).Start(ctx)
+	logger.Infof(ctx, "Started propeller webhook")
+	<-ctx.Done()
+
+	return nil
 }
 
 func createMutationConfig(ctx context.Context, kubeClient *kubernetes.Clientset, webhookObj *PodMutator, defaultNamespace string) error {


### PR DESCRIPTION
# TL;DR
This PR moves starting the controller-runtime manager outside of the webhook `Run` function. This is useful to ensure the controller-runtime manager starts in single binary even if the webhook is disabled.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3546

## Follow-up issue
_NA_
