### PR TITLE
Fixing recovering of SKIPPED nodes

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -216,7 +216,7 @@ func (c *nodeExecutor) attemptRecovery(ctx context.Context, nCtx handler.NodeExe
 	// A recoverable node execution should always be in a terminal phase
 	switch recovered.Closure.Phase {
 	case core.NodeExecution_SKIPPED:
-		return handler.PhaseInfoSkip(nil, "node execution recovery indicated original node was skipped"), nil
+		return handler.PhaseInfoUndefined, nil
 	case core.NodeExecution_SUCCEEDED:
 		fallthrough
 	case core.NodeExecution_RECOVERED:


### PR DESCRIPTION
# TL;DR
[The PR](https://github.com/flyteorg/flytepropeller/pull/518) to enable recovering dynamic workflows when they have already compiled the workflow closure updated the node executor to [always use the phase returned](https://github.com/flyteorg/flytepropeller/blob/7ff7f96cd35c8e5ae0eb9a1a22b769c7f9930530/pkg/controller/nodes/executor.go#L385) from `attemptRecovery`. This [surfaced an issue where nodes](https://github.com/flyteorg/flytepropeller/blob/986f014ae69505353833c20a38d4a58094b800cc/pkg/controller/nodes/executor.go#L218-L219) in the `SKIPPED` phase were reported as `SKIPPED` during recovery when they should be executed in the recovered workflow.

This PR correctly reports the phase of previously `SKIPPED` nodes as `UNDEFINED` to ensure the nodes are correctly evaluated during workflow recoveries.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3578

## Follow-up issue
_NA_
