### PR TITLE
Not stripping structure from literal types

### DIFF
--- a/pkg/compiler/transformers/k8s/utils.go
+++ b/pkg/compiler/transformers/k8s/utils.go
@@ -86,8 +86,10 @@ func StripTypeMetadata(t *core.LiteralType) *core.LiteralType {
 
 	c := *t
 	c.Metadata = nil
-	c.Structure = nil
 	c.Annotation = nil
+	// Note that we cannot strip `Structure` from the type because the dynamic node output type is used to validate the
+	// interface of the dynamically compiled workflow. `Structure` is used to extend type checking information on
+	// differnent Flyte types and is therefore required to ensure correct type validation.
 
 	switch underlyingType := c.Type.(type) {
 	case *core.LiteralType_UnionType:


### PR DESCRIPTION
# TL;DR
This PR leave the `Structure` field populated when stripping type metadata. This is necessary because it is used during type validation - particularly for the internally compiled workflow of dynamic tasks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3582

## Follow-up issue
_NA_
