### PR TITLE
Fix usage of archive replacements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,33 +29,23 @@ builds:
 archives:
   - id: kubectl-flyte-archive
     name_template: |-
-      kubectl-flyte_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
-      {{- with .Arm -}}
-      {{- if (eq . "6") -}}hf
-      {{- else -}}v{{- . -}}
-      {{- end -}}
-      {{- end -}}
+      kubectl-flyte_{{ .Tag }}_{{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     builds:
       - kubectl-flyte
-    replacements:
-      386: i386
-      amd64: x86_64
     format_overrides:
       - goos: windows
         format: zip
   - id: flytepropeller-archive
     name_template: |-
-      flytepropeller_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
-      {{- with .Arm -}}
-      {{- if (eq . "6") -}}hf
-      {{- else -}}v{{- . -}}
-      {{- end -}}
-      {{- end -}}
+      flytepropeller_{{ .Tag }}_{{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     builds:
       - flytepropeller
-    replacements:
-      386: i386
-      amd64: x86_64
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
# TL;DR
Produce archives using the recommended alternative for archives.replacements

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
`archives.replacements` was deprecated and removed in the latest goreleaser version as per https://goreleaser.com/deprecations/#archivesreplacements. This PR follows the recommendation to use `name_template` to get the same effect.

I removed the unused `{{ .Arm }}` block also.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
