### PR TITLE
Parallelize Node Evaluations

### DIFF
--- a/pkg/controller/executors/execution_context.go
+++ b/pkg/controller/executors/execution_context.go
@@ -1,6 +1,7 @@
 package executors
 
 import (
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytepropeller/pkg/apis/flyteworkflow/v1alpha1"
 )
 
@@ -33,12 +34,18 @@ type ControlFlow interface {
 	IncrementParallelism() uint32
 }
 
+type NodeExecutor interface {
+	AddNodeFuture(func(chan<- NodeExecutionResult))
+	Wait() (NodeStatus, error)
+}
+
 type ExecutionContext interface {
 	ImmutableExecutionContext
 	TaskDetailsGetter
 	SubWorkflowGetter
 	ParentInfoGetter
 	ControlFlow
+	NodeExecutor
 }
 
 type execContext struct {
@@ -47,6 +54,7 @@ type execContext struct {
 	TaskDetailsGetter
 	SubWorkflowGetter
 	parentInfo ImmutableParentInfo
+	NodeExecutor
 }
 
 func (e execContext) GetParentInfo() ImmutableParentInfo {
@@ -81,6 +89,82 @@ func (c *controlFlow) IncrementParallelism() uint32 {
 	return c.v
 }
 
+type NodeExecutionResult struct {
+	Err        error
+	NodeStatus NodeStatus
+}
+
+type nodeExecutor struct {
+	nodeFutures []<-chan NodeExecutionResult
+}
+
+func (n *nodeExecutor) AddNodeFuture(f func(chan<- NodeExecutionResult)) {
+	nodeFuture := make(chan NodeExecutionResult, 1)
+	go f(nodeFuture)
+	n.nodeFutures = append(n.nodeFutures, nodeFuture)
+}
+
+func (n *nodeExecutor) Wait() (NodeStatus, error) {
+	if len(n.nodeFutures) == 0 {
+		return NodeStatusComplete, nil
+	}
+
+	// If any downstream node is failed, fail, all
+	// Else if all are success then success
+	// Else if any one is running then Downstream is still running
+	allCompleted := true
+	partialNodeCompletion := false
+	onFailurePolicy := v1alpha1.WorkflowOnFailurePolicy(core.WorkflowMetadata_FAIL_IMMEDIATELY)
+	//onFailurePolicy := execContext.GetOnFailurePolicy() // TODO @hamersaw - need access to this
+	stateOnComplete := NodeStatusComplete
+	for _, nodeFuture := range n.nodeFutures {
+		nodeExecutionResult := <-nodeFuture
+		state := nodeExecutionResult.NodeStatus
+		err := nodeExecutionResult.Err
+		if err != nil { // TODO @hamersaw - do we want to fail right away? or wait until all nodes are done?
+			return NodeStatusUndefined, err
+		}
+
+		if state.HasFailed() || state.HasTimedOut() {
+			// TODO @hamersaw - Debug?
+			//logger.Debugf(ctx, "Some downstream node has failed. Failed: [%v]. TimedOut: [%v]. Error: [%s]", state.HasFailed(), state.HasTimedOut(), state.Err)
+			if onFailurePolicy == v1alpha1.WorkflowOnFailurePolicy(core.WorkflowMetadata_FAIL_AFTER_EXECUTABLE_NODES_COMPLETE) {
+				// If the failure policy allows other nodes to continue running, do not exit the loop,
+				// Keep track of the last failed state in the loop since it'll be the one to return.
+				// TODO: If multiple nodes fail (which this mode allows), consolidate/summarize failure states in one.
+				stateOnComplete = state
+			} else {
+				return state, nil
+			}
+		} else if !state.IsComplete() {
+			// A Failed/Timedout node is implicitly considered "complete" this means none of the downstream nodes from
+			// that node will ever be allowed to run.
+			// This else block, therefore, deals with all other states. IsComplete will return true if and only if this
+			// node as well as all of its downstream nodes have finished executing with success statuses. Otherwise we
+			// mark this node's state as not completed to ensure we will visit it again later.
+			allCompleted = false
+		}
+
+		if state.PartiallyComplete() {
+			// This implies that one of the downstream nodes has just succeeded and workflow is ready for propagation
+			// We do not propagate in current cycle to make it possible to store the state between transitions
+			partialNodeCompletion = true
+		}
+	}
+
+	if allCompleted {
+		// TODO @hamersaw - Debug?
+		//logger.Debugf(ctx, "All downstream nodes completed")
+		return stateOnComplete, nil
+	}
+
+	if partialNodeCompletion {
+		return NodeStatusSuccess, nil
+	}
+
+	return NodeStatusPending, nil
+}
+
 func NewExecutionContextWithTasksGetter(prevExecContext ExecutionContext, taskGetter TaskDetailsGetter) ExecutionContext {
 	return NewExecutionContext(prevExecContext, taskGetter, prevExecContext, prevExecContext.GetParentInfo(), prevExecContext)
 }
@@ -100,6 +184,7 @@ func NewExecutionContext(immExecContext ImmutableExecutionContext, tasksGetter T
 		SubWorkflowGetter:         workflowGetter,
 		parentInfo:                parentInfo,
 		ControlFlow:               flow,
+		NodeExecutor:              &nodeExecutor{},
 	}
 }
 

--- a/pkg/controller/executors/node.go
+++ b/pkg/controller/executors/node.go
@@ -74,7 +74,7 @@ type Node interface {
 	// - 1. It finds a blocking node (not ready, or running)
 	// - 2. A node fails and hence the workflow will fail
 	// - 3. The final/end node has completed and the workflow should be stopped
-	RecursiveNodeHandler(ctx context.Context, execContext ExecutionContext, dag DAGStructure, nl NodeLookup, currentNode v1alpha1.ExecutableNode) (NodeStatus, error)
+	RecursiveNodeHandler(ctx context.Context, execContext ExecutionContext, dag DAGStructure, nl NodeLookup, currentNode v1alpha1.ExecutableNode) error
 
 	// This aborts the given node. If the given node is complete then it recursively finds the running nodes and aborts them
 	AbortHandler(ctx context.Context, execContext ExecutionContext, dag DAGStructure, nl NodeLookup, currentNode v1alpha1.ExecutableNode, reason string) error

--- a/pkg/controller/nodes/branch/handler.go
+++ b/pkg/controller/nodes/branch/handler.go
@@ -145,7 +145,10 @@ func (b *branchHandler) recurseDownstream(ctx context.Context, nCtx handler.Node
 	if err != nil {
 		return handler.UnknownTransition, err
 	}
-	downstreamStatus, err := b.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dag, nCtx.ContextualNodeLookup(), branchTakenNode)
+	if err := b.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dag, nCtx.ContextualNodeLookup(), branchTakenNode); err != nil {
+		return handler.UnknownTransition, err
+	}
+	downstreamStatus, err := execContext.Wait()
 	if err != nil {
 		return handler.UnknownTransition, err
 	}

--- a/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -267,7 +267,10 @@ func (d dynamicNodeTaskNodeHandler) buildDynamicWorkflow(ctx context.Context, nC
 func (d dynamicNodeTaskNodeHandler) progressDynamicWorkflow(ctx context.Context, execContext executors.ExecutionContext, dynamicWorkflow v1alpha1.ExecutableWorkflow, nl executors.NodeLookup,
 	nCtx handler.NodeExecutionContext, prevState handler.DynamicNodeState) (handler.Transition, handler.DynamicNodeState, error) {
 
-	state, err := d.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dynamicWorkflow, nl, dynamicWorkflow.StartNode())
+	if err := d.nodeExecutor.RecursiveNodeHandler(ctx, execContext, dynamicWorkflow, nl, dynamicWorkflow.StartNode()); err != nil {
+		return handler.UnknownTransition, prevState, err
+	}
+	state, err := execContext.Wait()
 	if err != nil {
 		return handler.UnknownTransition, prevState, err
 	}

--- a/pkg/controller/nodes/subworkflow/subworkflow.go
+++ b/pkg/controller/nodes/subworkflow/subworkflow.go
@@ -71,7 +71,10 @@ func (s *subworkflowHandler) handleSubWorkflow(ctx context.Context, nCtx handler
 		return handler.UnknownTransition, err
 	}
 	execContext := executors.NewExecutionContextWithParentInfo(nCtx.ExecutionContext(), newParentInfo)
-	state, err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.StartNode())
+	if err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.StartNode()); err != nil {
+		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
+	}
+	state, err := execContext.Wait()
 	if err != nil {
 		return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
 	}
@@ -150,7 +153,10 @@ func (s *subworkflowHandler) HandleFailureNodeOfSubWorkflow(ctx context.Context,
 		if err != nil {
 			return handler.UnknownTransition, err
 		}
-		state, err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.GetOnFailureNode())
+		if err := s.nodeExecutor.RecursiveNodeHandler(ctx, execContext, subworkflow, nl, subworkflow.GetOnFailureNode()); err != nil {
+			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
+		}
+		state, err := execContext.Wait()
 		if err != nil {
 			return handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoUndefined), err
 		}


### PR DESCRIPTION
# TL;DR
This PR parallelizes node evaluations by using go channels to call the `handleNode` function in a separate go routine and then waiting on all evaluations before compiling overall workflow status.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3866

## Follow-up issue
_NA_
