### PR TITLE
Add support namespace override

### DIFF
--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -102,9 +102,7 @@ type PluginManager struct {
 }
 
 func (e *PluginManager) AddObjectMetadata(taskCtx pluginsCore.TaskExecutionMetadata, o client.Object, cfg *config.K8sPluginConfig) {
-	if len(o.GetNamespace()) == 0 {
-		o.SetNamespace(taskCtx.GetNamespace())
-	}
+	o.SetNamespace(taskCtx.GetNamespace())
 	o.SetAnnotations(utils.UnionMaps(cfg.DefaultAnnotations, o.GetAnnotations(), utils.CopyMap(taskCtx.GetAnnotations())))
 	o.SetLabels(utils.UnionMaps(cfg.DefaultLabels, o.GetLabels(), utils.CopyMap(taskCtx.GetLabels())))
 	o.SetName(taskCtx.GetTaskExecutionID().GetGeneratedName())

--- a/pkg/controller/nodes/task/k8s/task_exec_context.go
+++ b/pkg/controller/nodes/task/k8s/task_exec_context.go
@@ -31,6 +31,7 @@ type TaskExecutionMetadata struct {
 
 	annotations map[string]string
 	labels      map[string]string
+	namespace   string
 }
 
 func (t TaskExecutionMetadata) GetLabels() map[string]string {
@@ -39,6 +40,10 @@ func (t TaskExecutionMetadata) GetLabels() map[string]string {
 
 func (t TaskExecutionMetadata) GetAnnotations() map[string]string {
 	return t.annotations
+}
+
+func (t TaskExecutionMetadata) GetNamespace() string {
+	return t.namespace
 }
 
 // newTaskExecutionMetadata creates a TaskExecutionMetadata with secrets serialized as annotations and a label added
@@ -57,10 +62,15 @@ func newTaskExecutionMetadata(tCtx pluginsCore.TaskExecutionMetadata, taskTmpl *
 			secrets.PodLabel: secrets.PodLabelValue,
 		}
 	}
+	namespace := tCtx.GetNamespace()
+	if len(taskTmpl.Metadata.Namespace) > 0 {
+		namespace = taskTmpl.Metadata.Namespace
+	}
 
 	return TaskExecutionMetadata{
 		TaskExecutionMetadata: tCtx,
 		annotations:           utils.UnionMaps(tCtx.GetAnnotations(), secretsMap),
 		labels:                utils.UnionMaps(tCtx.GetLabels(), injectSecretsLabel),
+		namespace:             namespace,
 	}, nil
 }


### PR DESCRIPTION
# TL;DR
- Instead of setting the namespace for the k8s resource every time, we set it only when the k8s resource's namespace is None
- Only add an owner reference if the task's namespace matches the Flyteworkflow's.
https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3898

## Follow-up issue
_NA_