### PR TITLE
Fixing max parallelism

### DIFF
--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -578,9 +578,6 @@ func (t Handler) Handle(ctx context.Context, nCtx interfaces.NodeExecutionContex
 			return handler.UnknownTransition, errors.Wrapf(errors.RuntimeExecutionError, nCtx.NodeID(), err, "failed during plugin execution")
 		}
 		if pluginTrns.IsPreviouslyObserved() {
-			if !pluginTrns.pInfo.Phase().IsTerminal() {
-				logger.Infof(ctx, "Parallelism now set to [%d].", nCtx.ExecutionContext().IncrementParallelism())
-			}
 			logger.Debugf(ctx, "No state change for Task, previously observed same transition. Short circuiting.")
 			return pluginTrns.FinalTransition(ctx)
 		}
@@ -667,9 +664,6 @@ func (t Handler) Handle(ctx context.Context, nCtx interfaces.NodeExecutionContex
 		return handler.UnknownTransition, err
 	}
 
-	if !pluginTrns.pInfo.Phase().IsTerminal() {
-		logger.Infof(ctx, "Parallelism now set to [%d].", nCtx.ExecutionContext().IncrementParallelism())
-	}
 	return pluginTrns.FinalTransition(ctx)
 }
 


### PR DESCRIPTION
# TL;DR
I run two tasks in a workflow, but max Parallelism is being set to 4.
```bash
{"json":{"exec_id":"ahcxqvqbwjs5zczg8d9b","node":"n0","ns":"flytesnacks-development","res_ver":"180043","routine":"worker-2","src":"handler.go:582","tasktype":"python-task","wf":"flytesnacks:development:getting_start.wf"},"level":"info","msg":"Parallelism now set to [1].","ts":"2023-08-29T14:37:15-07:00"}
{"json":{"exec_id":"ahcxqvqbwjs5zczg8d9b","node":"n0","ns":"flytesnacks-development","res_ver":"180043","routine":"worker-2","src":"handler.go:540","tasktype":"python-task","wf":"flytesnacks:development:getting_start.wf"},"level":"info","msg":"Parallelism now set to [2].","ts":"2023-08-29T14:37:15-07:00"}
{"json":{"exec_id":"ahcxqvqbwjs5zczg8d9b","node":"n0","ns":"flytesnacks-development","res_ver":"180043","routine":"worker-2","src":"handler.go:91","wf":"flytesnacks:development:getting_start.wf"},"level":"info","msg":"regular node detected, (no future file found)","ts":"2023-08-29T14:37:15-07:00"}
{"json":{"exec_id":"ahcxqvqbwjs5zczg8d9b","node":"n1","ns":"flytesnacks-development","res_ver":"180043","routine":"worker-2","src":"handler.go:183","wf":"flytesnacks:development:getting_start.wf"},"level":"info","msg":"Dynamic handler.Handle's called with phase 0.","ts":"2023-08-29T14:37:15-07:00"}
{"json":{"exec_id":"ahcxqvqbwjs5zczg8d9b","node":"n1","ns":"flytesnacks-development","res_ver":"180043","routine":"worker-2","src":"handler.go:582","tasktype":"python-task","wf":"flytesnacks:development:getting_start.wf"},"level":"info","msg":"Parallelism now set to [3].","ts":"2023-08-29T14:37:15-07:00"}
{"json":{"exec_id":"ahcxqvqbwjs5zczg8d9b","node":"n1","ns":"flytesnacks-development","res_ver":"180043","routine":"worker-2","src":"handler.go:540","tasktype":"python-task","wf":"flytesnacks:development:getting_start.wf"},"level":"info","msg":"Parallelism now set to [4].","ts":"2023-08-29T14:37:15-07:00"}
```

We use [defer func](https://github.com/flyteorg/flytepropeller/blob/9cec7c0436e9a765c07e590b20cbe626f635e8c5/pkg/controller/nodes/task/handler.go#L536-L542) to update the max parallelism, so we don't need to update the parallelism in other places in the `handle()`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
