### PR TITLE
Add supportTaskTypes for agentservice without write it in config twice.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/benlaurie/objecthash v0.0.0-20180202135721-d1e3d6079fc1
 	github.com/fatih/color v1.13.0
 	github.com/flyteorg/flyteidl v1.5.13
-	github.com/flyteorg/flyteplugins v1.1.16
-	github.com/flyteorg/flytestdlib v1.0.22
+	github.com/flyteorg/flyteplugins v1.1.29
+	github.com/flyteorg/flytestdlib v1.0.24
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/go-test/deep v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -244,10 +244,10 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flyteorg/flyteidl v1.5.13 h1:IQ2Cw+u36ew3BPyRDAcHdzc/GyNEOXOxhKy9jbS4hbo=
 github.com/flyteorg/flyteidl v1.5.13/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
-github.com/flyteorg/flyteplugins v1.1.16 h1:DIQxPERFMvTGnLTkkeG9R8STF3YMvxK1nPtFf+a6o5Q=
-github.com/flyteorg/flyteplugins v1.1.16/go.mod h1:HEd4yf0H8XfxMcHFwrTdTIJ/9lEAz83OpgcFQe47L6I=
-github.com/flyteorg/flytestdlib v1.0.22 h1:8RAc+TmME54FInf4+t6+C7X8Z/dW6i6aTs6W8SEzpI8=
-github.com/flyteorg/flytestdlib v1.0.22/go.mod h1:6nXa5g00qFIsgdvQ7jKQMJmDniqO0hG6Z5X5olfduqQ=
+github.com/flyteorg/flyteplugins v1.1.29 h1:75I045EgfwNcyYzDhNwWye80+nyMmWmiEW3G+kOvOxc=
+github.com/flyteorg/flyteplugins v1.1.29/go.mod h1:FujFQdL/f9r1HvFR81JCiNYusDy9F0lExhyoyMHXXbg=
+github.com/flyteorg/flytestdlib v1.0.24 h1:jDvymcjlsTRCwOtxPapro0WZBe3isTz+T3Tiq+mZUuk=
+github.com/flyteorg/flytestdlib v1.0.24/go.mod h1:6nXa5g00qFIsgdvQ7jKQMJmDniqO0hG6Z5X5olfduqQ=
 github.com/flyteorg/stow v0.3.7 h1:Cx7j8/Ux6+toD5hp5fy++927V+yAcAttDeQAlUD/864=
 github.com/flyteorg/stow v0.3.7/go.mod h1:5dfBitPM004dwaZdoVylVjxFT4GWAgI0ghAndhNUzCo=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/pkg/controller/nodes/task/plugin_config.go
+++ b/pkg/controller/nodes/task/plugin_config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/flyteorg/flytepropeller/pkg/controller/nodes/task/k8s"
 )
 
+const AgentServiceKey = "agent-service"
+
 var once sync.Once
 
 func WranglePluginsAndGenerateFinalList(ctx context.Context, cfg *config.TaskPluginConfig, pr PluginRegistryIface) (enabledPlugins []core.PluginEntry, defaultForTaskTypes map[pluginID][]taskType, err error) {
@@ -24,8 +26,9 @@ func WranglePluginsAndGenerateFinalList(ctx context.Context, cfg *config.TaskPlu
 	}
 
 	// Register the GRPC plugin after the config is loaded
-	once.Do(func() { agent.RegisterAgentPlugin() })
 	pluginsConfigMeta, err := cfg.GetEnabledPlugins()
+	once.Do(func() { agent.RegisterAgentPlugin(pluginsConfigMeta.AllDefaultForTaskTypes[AgentServiceKey]) })
+
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
# TL;DR
As title.
Note: Please merge the code below, so that the code will work!
https://github.com/flyteorg/flyteplugins/pull/398
## Type
 - [ ] Bug Fix
 - [x] Feature
 - [x] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Right now, the agent-service section doesn't need to add supportedTaskTypes anymore.
We can get it by "default-for-task-types" from tasks.
![image](https://github.com/flyteorg/flytepropeller/assets/76461262/5e603439-5b15-4fdb-b872-7896ed5e745c)
![image](https://github.com/flyteorg/flytepropeller/assets/76461262/3071fb34-9db0-4131-aabb-633f52ff00e2)

## Tracking Issue
https://github.com/flyteorg/flyteplugins/pull/398