### PR TITLE
Read PodTemplates by default.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -598,9 +598,7 @@ func StartController(ctx context.Context, cfg *config.Config, defaultNamespace s
 	}
 
 	go flyteworkflowInformerFactory.Start(ctx.Done())
-	if flyteK8sConfig.GetK8sPluginConfig().DefaultPodTemplateName != "" {
-		go informerFactory.Start(ctx.Done())
-	}
+	go informerFactory.Start(ctx.Done())
 
 	if err = c.Run(ctx); err != nil {
 		return errors.Wrapf(err, "Error running FlytePropeller.")


### PR DESCRIPTION
# TL;DR
This PR let PodTemplates read by default.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Remove the condition check for setting the default podTemplates name when starting the informerFactory.

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/3946

## Follow-up issue
_NA_
