### PR TITLE
Removing event mocking in ArrayNode

### DIFF
--- a/pkg/controller/nodes/array/node_execution_context.go
+++ b/pkg/controller/nodes/array/node_execution_context.go
@@ -117,9 +117,9 @@ type arrayNodeExecutionContext struct {
 	taskReader       interfaces.TaskReader
 }
 
-func (a *arrayNodeExecutionContext) EventsRecorder() interfaces.EventRecorder {
+/*func (a *arrayNodeExecutionContext) EventsRecorder() interfaces.EventRecorder {
 	return a.eventRecorder
-}
+}*/
 
 func (a *arrayNodeExecutionContext) ExecutionContext() executors.ExecutionContext {
 	return a.executionContext


### PR DESCRIPTION
# TL;DR
Using a flag to indicate if ArrayNode should use maptask legacy eventing or not mock anything and use parent/child relationships to send full subtask metadata.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
