### PR TITLE
Reverting to parallelism increases only on non-terminal phase updates

### DIFF
--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -533,13 +533,6 @@ func (t Handler) Handle(ctx context.Context, nCtx interfaces.NodeExecutionContex
 	ts := nCtx.NodeStateReader().GetTaskNodeState()
 
 	pluginTrns := &pluginRequestedTransition{}
-	defer func() {
-		// increment parallelism if the final pluginTrns is not in a terminal state
-		if pluginTrns != nil && !pluginTrns.pInfo.Phase().IsTerminal() {
-			eCtx := nCtx.ExecutionContext()
-			logger.Infof(ctx, "Parallelism now set to [%d].", eCtx.IncrementParallelism())
-		}
-	}()
 
 	// We will start with the assumption that catalog is disabled
 	pluginTrns.PopulateCacheInfo(catalog.NewFailedCatalogEntry(catalog.NewStatus(core.CatalogCacheStatus_CACHE_DISABLED, nil)))
@@ -664,6 +657,10 @@ func (t Handler) Handle(ctx context.Context, nCtx interfaces.NodeExecutionContex
 		return handler.UnknownTransition, err
 	}
 
+	// increment parallelism if the final pluginTrns is not in a terminal state
+	if pluginTrns != nil && !pluginTrns.pInfo.Phase().IsTerminal() {
+		logger.Infof(ctx, "Parallelism now set to [%d].", nCtx.ExecutionContext().IncrementParallelism())
+	}
 	return pluginTrns.FinalTransition(ctx)
 }
 


### PR DESCRIPTION
# TL;DR
These two ([1](https://github.com/flyteorg/flytepropeller/pull/594) and [2](https://github.com/flyteorg/flytepropeller/pull/611)) changes attempted to fix parallelism computations. However, they introduced additional issues where now if a node in the DAG is visited multiple times in the same round it may count each time towards the parallelism. This PR reverts to previous parallelism computation (which may still be incorrect in certain scenarios).

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
